### PR TITLE
Fix the link to the chat page, remove the webchat links.

### DIFF
--- a/content/pages/community/_index.md
+++ b/content/pages/community/_index.md
@@ -43,7 +43,7 @@ The XMPP Community is one of the standard's greatest assets, full of many helpfu
 
 You can find us in a variety of places:
 
-- Community [chat rooms](/community-chat) (of course!)
+- Community [chat rooms](/community/chat) (of course!)
 - Our [mailing lists](/community/mailing-lists)
 - Attending and organizing [events](/community/events)
 

--- a/content/pages/community/chat.md
+++ b/content/pages/community/chat.md
@@ -28,12 +28,12 @@ Content_layout: multiple-columns
 The XSF hosts a variety of chat rooms and all archives are available online.
 
 ### Jabber support chatroom
-Chat about using Jabber/XMPP technologies ([webchat](http://speeqe.com/room/jabber@conference.jabber.org/) | [join](xmpp:jabber@conference.jabber.org?join) | [logs](http://logs.jabber.org/jabber@conference.jabber.org/))
+Chat about using Jabber/XMPP technologies ([join](xmpp:jabber@conference.jabber.org?join) | [logs](http://logs.jabber.org/jabber@conference.jabber.org/))
 
 ### Operators chatroom
-Chat about the Jabber/XMPP network ([webchat](http://speeqe.com/room/operators@conference.jabber.org/) | [join](xmpp:operators@conference.jabber.org?join) | [logs](http://logs.jabber.org/operators@conference.jabber.org/))
+Chat about the Jabber/XMPP network ([join](xmpp:operators@conference.jabber.org?join) | [logs](http://logs.jabber.org/operators@conference.jabber.org/))
 
 ### Developer chatroom
-Chat about software and protocols ([webchat](http://speeqe.com/room/jdev@conference.jabber.org/) | [join](xmpp:jdev@conference.jabber.org?join) | [logs](http://logs.jabber.org/jdev@conference.jabber.org/))
+Chat about software and protocols ([join](xmpp:jdev@conference.jabber.org?join) | [logs](http://logs.jabber.org/jdev@conference.jabber.org/))
 
 All of these venues are completely free and open to any interested individual.


### PR DESCRIPTION
The link to the "Chat" page from the "Community" page was broken.

Also, it seems that the "speeqe.com" domain expired and is now owned by a domain squatter, so I think it's best to remove links to it completely. There might be other webchats that can be used to access these rooms, but I don't know of any.