### PR TITLE
Correct the MUC in the README to xsf@muc.xmpp.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Contributing new content and updates
 Communication forum
 -------------------
 
-Please use [members@muc.xmpp.org](xmpp:members@muc.xmpp.org?join) for discussions about the site, content, generation etc.
+Please use [xsf@muc.xmpp.org](xmpp:xsf@muc.xmpp.org?join) for discussions about the site, content, generation etc.
 
 Site generation
 ---------------


### PR DESCRIPTION
The members@muc.xmpp.org room does not appear to exist. From discussion in the xsf@ room, it appears that room is the proper place.