### PR TITLE
Remove the fixed width in logos.sass

### DIFF
--- a/xmpp.org-theme/sass/components/logos.sass
+++ b/xmpp.org-theme/sass/components/logos.sass
@@ -1,5 +1,4 @@
 .logo-software
-  width: 50px
   height: 50px
   vertical-align: middle
   text-align: center


### PR DESCRIPTION
Not all logos have a 1:1 ratio. The Apple logo is looking quite bad, because it is 748x909. Removing the width but leaving the height makes them all look consistent.