### PR TITLE
add MongooseIM as an implementation for MUC and BOSH

### DIFF
--- a/content/pages/about/overview.md
+++ b/content/pages/about/overview.md
@@ -233,6 +233,7 @@ Servers The following XMPP servers include built-in support for BOSH:
 - [Openfire](http://www.igniterealtime.org/projects/openfire/index.jsp)
 - [Prosody](http://prosody.im/)
 - [Tigase](http://www.tigase.org/)
+- [MongooseIM](https://github.com/esl/MongooseIM)
 
 #### Connection Managers
 

--- a/content/pages/about/overview.md
+++ b/content/pages/about/overview.md
@@ -146,6 +146,7 @@ __Servers__ - the following XMPP servers include built-in support for MUC:
 - [Openfire](http://www.igniterealtime.org/projects/openfire/index.jsp)
 - [Prosody](http://prosody.im/)
 - [Tigase](http://www.tigase.org/)
+- [MongooseIM](https://github.com/esl/MongooseIM)
 
 __External Components__ - the following standalone components can be used with a wide variety of XMPP servers:
 


### PR DESCRIPTION
MongooseIM's implementation of MUC and BOSH are not the same as ejabberd's. Both are
complete rewrites with huge improvements in terms of scalability as
bottlenecks have been removed.