### PR TITLE
Link to WhatsApp should not be relative.

### DIFF
--- a/content/pages/software/projects.md
+++ b/content/pages/software/projects.md
@@ -28,5 +28,5 @@ And don't forget to also submit a pull request to add your organization as an [X
 | Users        | Company         | Use              | Description                            |
 |--------------|-----------------|---------------|----------------------------------------|
 | ~1.5 billion | [Google](https://google.com) | Push Notifications | Google provides an [XMPP Interface](https://developers.google.com/cloud-messaging/server) to their push notification service. It's also been rumoured that push notifications are delivered to the device via a propriatary binary XMPP protocol. | 
-| ~800 million | [WhatsApp](whatsapp.com) |  Chat | WhatApp uses a [variation of XMPP](https://github.com/WHAnonymous/Chat-API/wiki/FunXMPP-Protocol) for its popular chat service | 
+| ~800 million | [WhatsApp](http://whatsapp.com) |  Chat | WhatApp uses a [variation of XMPP](https://github.com/WHAnonymous/Chat-API/wiki/FunXMPP-Protocol) for its popular chat service | 
 | ~500 million | [Apple](http://apple.com)  | Push Notifications | Apple uses [XMPP to deliver push notifications](https://www.quora.com/What-technology-does-the-iOS-Apple-Push-Notification-Service-APNS-use-to-maintain-a-persistent-connection-with-each-device-to-receive-such-fast-push-notifications) to client devices. 


### PR DESCRIPTION
Added a URL scheme to force an absolute link.