### PR TITLE
Add page: /about/the-jabber-project

### DIFF
--- a/content/pages/about/history.md
+++ b/content/pages/about/history.md
@@ -3,35 +3,14 @@ Title: History of XMPP
 Url: about/history
 Save_as: about/history.html
 Parent_id: about
-Top_menu_show: false
-Top_Menu_order: -1
-Dropdown_menu_show: false
-Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About XMPP
-Sidebar_menu_size: 8
-Sidebar_menu_elem_name_1: Features and benefits
-Sidebar_menu_elem_url_1: about/features-and-benefits
-Sidebar_menu_elem_name_2: History
-Sidebar_menu_elem_url_2: about/history
-Sidebar_menu_elem_name_3: Overview
-Sidebar_menu_elem_url_3: about/technology-overview
-Sidebar_menu_elem_name_4: Who uses XMPP
-Sidebar_menu_elem_url_4: about/who-uses-xmpp
-Sidebar_menu_elem_name_5: Standards Process
-Sidebar_menu_elem_url_5: about/standards-process
-Sidebar_menu_elem_name_6: The XSF
-Sidebar_menu_elem_url_6: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_7: Extensions
-Sidebar_menu_elem_url_7: extensions/index
-Sidebar_menu_elem_name_8: FAQ
-Sidebar_menu_elem_url_8: about/faq
+Inherit_sidebar: true
 Content_layout: multiple-columns
 ---
 
 ## 1999
 - __January:__ Jeremie Miller announces the existence of Jabber; an open technology for instant messaging and presence. Throughout the year development moves quickly on an open source server (jabberd), several open-source clients and code libraries, and open wire protocols for real-time XML streaming; as well as basic instant messaging and presence extensions. These same base protocols (with various improvements and extensions) are still in use today.
-- __August:__ Jeremie submits a statement pledging the Jabber community’s support for the IETF standards process. This statement is consistent with the founding mission of the Jabber project: to foster freedom of conversation and support open standards and interoperability in real-time communications.
+- __August:__ Jeremie submits a [statement](/about/the-jabber-project) pledging the Jabber community’s support for the IETF standards process. This statement is consistent with the founding mission of the Jabber project: to foster freedom of conversation and support open standards and interoperability in real-time communications.
 
 ## 2000
 - __February:__ The IETF publish work done by the Instant Messaging and Presence Protocol (IMPP) Working Group; in short, a model and set of requirements for instant messaging and presence systems.

--- a/content/pages/about/the-jabber-project.md
+++ b/content/pages/about/the-jabber-project.md
@@ -1,0 +1,31 @@
+---
+Title: The Jabber Project
+Url: about/the-jabber-project
+Save_as: about/the-jabber-project.html
+Parent_id: about
+Sidebar_menu_show: true
+Inherit_sidebar: true
+Content_layout: multiple-columns
+---
+_Note: This is the original statement provided by Jeremie Miller, inventor of Jabber/XMPP technologies, regarding the early Jabber project’s involvement with and support for the IETF’s standardization efforts with respect to instant messaging and presence._
+
+**The Jabber Project:  
+Statement on IETF Activity  
+by Jeremie <[jeremie@jabber.org](mailto:jeremie@jabber.org)>**
+
+### Introduction
+
+> Jabber <[http://jabber.org/](http://jabber.org/)> is an open-source effort to create an open real-time messaging architecture that offers transparent compatibility with other real-time messaging services and protocols. Recent attention has been drawn to the real-time messaging market by the activities of Microsoft and AOL, as a result of this both parties have commited to support the efforts of the IETF IMPP Working Group <[http://www.ietf.org/html.charters/impp-charter.html](http://www.ietf.org/html.charters/impp-charter.html)>.
+
+### IETF Support
+
+> Jabber is an open development project and is commited to fully support any open real-time messaging protocols, including the IETF recommended protocol. When such protocol is available, users of Jabber software and services will automatically be allowed to communicate with users of the IETF protocol. As support for the IETF efforts grows, Jabber is aiming to create a leading open-source platform around its IETF support.
+
+### IETF Activity
+
+> The IMPP Working Group is currently entering the design phase for its protocol. Developers of the Jabber Project have been following the creation of the existing requirements draft closely, and expect to participate in the development of the protocol within the IMPP group. Based on the requirements draft, the protocol already used internally to Jabber is an existing possible candidate for the recommended protocol. As the IETF activity in designing the protocol continues, Jabber will be aligned as closely as possible to the discussions and requirements, and lobbied as a test platform for IMPP development efforts.
+
+Any specific questions about this document or Jabber can be directed to the Jabber Development Team at <[team@jabber.org](mailto:team@jabber.org)>.
+
+[Copyright 1999 Jabber Development Team, All Rights Reserved]  
+[Modified Aug 9, 1999 By [jeremie@jabber.org](mailto:jeremie@jabber.org)]


### PR DESCRIPTION
Previously missing, linked from on the /about/history page.