### PR TITLE
Clean up Atom feeds

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -34,3 +34,11 @@ YEAR_ARCHIVE_SAVE_AS = '{date:%Y}/index.html'
 THEME = "xmpp.org-theme"
 
 MD_EXTENSIONS = [ 'codehilite(css_class=highlight)', 'extra' ]
+
+FEED_MAX_ITEMS = 20
+AUTHOR_FEED_ATOM = None
+AUTHOR_FEED_RSS = None
+CATEGORY_FEED_ATOM = None
+CATEGORY_FEED_RSS = None
+TAG_FEED_ATOM = None
+TAG_FEED_RSS = None

--- a/xmpp.org-theme/templates/base.html
+++ b/xmpp.org-theme/templates/base.html
@@ -7,6 +7,7 @@
   <link rel="shortcut icon" href="{{ SITE_URL }}/theme/images/xmpp-logo.png" />
   <link rel="stylesheet" href="{{ SITE_URL }}/theme/css/app.css" type="text/css" />
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Exo+2:700,400|Merriweather:300italic,300,700" type="text/css" />
+  {% if active_page_is_blog|default("false") == "true" %}<link rel="alternate" href="/feeds/all.atom.xml" type="application/atom+xml" name="Blog feed" />{% endif %}
 </head>
 <body class="{{ active_page }}" style="overflow-y: scroll;">
   {% include 'top_menu.html' %}
@@ -27,6 +28,8 @@
         {% endblock %}
       </div>
       <div class="sidebar large-4 medium-4 columns">
+        {% block blog_feeds %}
+        {% endblock %}
         {% block blog_categories %}
         {% endblock %}
         {% block blog_archives %}

--- a/xmpp.org-theme/templates/feeds.html
+++ b/xmpp.org-theme/templates/feeds.html
@@ -1,0 +1,7 @@
+<!-- <h4>
+  <a href="{{ SITE_URL }}/resources">Resources &raquo;</a>
+</h4> -->
+<h4>Feeds</h4>
+<ul>
+	<li><a href="/{{ FEED_ALL_ATOM }}">Atom</a></li>
+</ul>

--- a/xmpp.org-theme/templates/index.html
+++ b/xmpp.org-theme/templates/index.html
@@ -33,6 +33,10 @@
 {% include 'pagination.html' %}
 {% endblock %}
 
+{% block blog_feeds %}
+  {% include "feeds.html" %}
+{% endblock %}
+
 {% block blog_categories %}
   {% include "categories.html" %}
 {% endblock %}


### PR DESCRIPTION
Atom feeds were generated for every author, and for every category.
Since we only use one category, misc, and I didn't see much value in
per-author feeds for xmpp.org, I disabled generation of this.

The blog page now lists a link to the Atom feed.  Each blog page also
has a <link/> to tell browsers where to find the feed.

This patch also limits the feeds to the 20 latest items.

Fixes #121