### PR TITLE
Fix links of those that can answer questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The [xmpp.org website plan](https://trello.com/b/ml9e82sE/xmpp-org-website) desc
 
 Please log any [issues](https://github.com/xsf/xmpp.org/issues/new).
 
-Any editorial questions: [Laura Gill](laura.gill@surevine.com) or [Simon Tennant](simon@buddycloud.com) can help
+Any editorial questions: [Laura Gill](xmpp:laura.gill@surevine.com) or [Simon Tennant](xmpp:simon@buddycloud.com) can help
 
 Contributing new content and updates
 ------------------------------------


### PR DESCRIPTION
When not providing a protocol, markdown resolves a link as a relative one.
I think both addresses double as a JID and email address. In the spirit of
the website, I opted for the former.