### PR TITLE
Fix Pelican's broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Site generation
 
 ## Gentle introduction to Pelican
 
-Pelican's [GETTING STARTED](http://docs.getpelican.com/en/latest/getting_started.html/) page is a good place to learn about the basics of Pelican (installation, project skeleton, development cycle, etc.).
+Pelican's [QUICKSTART](http://docs.getpelican.com/en/latest/quickstart.html/) page is a good place to learn about the basics of Pelican (installation, project skeleton, development cycle, etc.).
 
 ### Installation instructions
 ```bash


### PR DESCRIPTION
Changes from getpelican/pelican@86e11c619d0208d9bc8418821c2e2a31e6f991ea split the Getting Started section into separate sections, breaking the link.