### PR TITLE
Add the xmpp-client by @agl to the clients list

### DIFF
--- a/content/pages/software/clients.md
+++ b/content/pages/software/clients.md
@@ -96,6 +96,7 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [VSTalk](http://codeplex.com)                         | Windows                                                |
 | [WTW](http://k2t.eu)                            | Windows                                                |
 | [Xabber](http://xabber.com)                         | Mobile (Android)                                       |
+| [xmpp-client](https://github.com/agl/xmpp-client) | Linux / OSX |
 | [xmppchat](http://babelmonkeys.de)                       | Browser                                                |
 | [XMPPWebChat](http://code.google.com)                    | Browser                                                |
 | [yaxim](http://yaxim.org)                          | Mobile (Android)                                       |


### PR DESCRIPTION
I noticed https://github.com/agl/xmpp-client was not on the list and I felt that it should be. It is a terminal application with a simple and friendly interface.