### PR TITLE
Add Sharp.Xmpp license

### DIFF
--- a/content/pages/software/libraries.md
+++ b/content/pages/software/libraries.md
@@ -74,7 +74,7 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [pyxmpp2](https://github.com/Jajcus/pyxmpp2)                              | Python                              |                  |
 | [QXmpp](www.qxmpp.org)                                                    | C++                                 |                  |
 | [seesmic-as3-xmpp](https://code.google.com/archive/p/seesmic-as3-xmpp)    | Flash / ActionScript                |                  |
-| [Sharp.Xmpp](https://github.com/pgstath/Sharp.Xmpp)                       | C#               |                  | MIT
+| [Sharp.Xmpp](https://github.com/pgstath/Sharp.Xmpp)                       | C# / .net / Mono                    | MIT              | 
 | [Skates](https://github.com/julien51/skates)                              | Ruby                                | MIT              |
 | [SleekXMPP](https://github.com/fritzy/SleekXMPP)                          | Python                              |                  |
 | [Smack](http://www.igniterealtime.org/projects/smack)                     | Java (Java SE 7 and Android)        | Apache 2.0       |


### PR DESCRIPTION
Apologies, previous commit was a late night one, and the library's license was not added properly;)