### PR TITLE
Clicking labels should toggle checkbox.

### DIFF
--- a/content/pages/extensions.html
+++ b/content/pages/extensions.html
@@ -72,16 +72,16 @@
     });
 </script>
 <p id="status-selector" class="jsSupport" style="display: none;">
-    <input type="checkbox" name="Active" checked="checked" /><label for="Active">Active</label>
-    <input type="checkbox" name="Deferred" /><label for="Deferred">Deferred</label>
-    <input type="checkbox" name="Deprecated" /><label for="Deprecated">Deprecated</label>
-    <input type="checkbox" name="Draft" checked="checked" /><label for="Draft">Draft</label>
-    <input type="checkbox" name="Experimental" checked="checked" /><label for="Experimental">Experimental</label>
-    <input type="checkbox" name="Final" checked="checked" /><label for="Final">Final</label>
-    <input type="checkbox" name="Obsolete" /><label for="Obsolete">Obsolete</label>
-    <input type="checkbox" name="Proposed" checked="checked" /><label for="Proposed">Proposed</label>
-    <input type="checkbox" name="Rejected" /><label for="Rejected">Rejected</label>
-    <input type="checkbox" name="Retracted" /><label for="Retracted">Retracted</label>
+    <input type="checkbox" id="Active" name="Active" checked="checked" /><label for="Active">Active</label>
+    <input type="checkbox" id="Deferred" name="Deferred" /><label for="Deferred">Deferred</label>
+    <input type="checkbox" id="Deprecated" name="Deprecated" /><label for="Deprecated">Deprecated</label>
+    <input type="checkbox" id="Draft" name="Draft" checked="checked" /><label for="Draft">Draft</label>
+    <input type="checkbox" id="Experimental" name="Experimental" checked="checked" /><label for="Experimental">Experimental</label>
+    <input type="checkbox" id="Final" name="Final" checked="checked" /><label for="Final">Final</label>
+    <input type="checkbox" id="Obsolete" name="Obsolete" /><label for="Obsolete">Obsolete</label>
+    <input type="checkbox" id="Proposed" name="Proposed" checked="checked" /><label for="Proposed">Proposed</label>
+    <input type="checkbox" id="Rejected" name="Rejected" /><label for="Rejected">Rejected</label>
+    <input type="checkbox" id="Retracted" name="Retracted" /><label for="Retracted">Retracted</label>
 </p>
 </form>
 <!--REPLACE_XEPLIST_TABLE_HERE-->


### PR DESCRIPTION
The labels on top of the extensions table should be clickable. Chromium
currently requires you to click the checkbox, but does not do anything
when the corresponding text is clicked.