### PR TITLE
Renaming 'extensions' to 'specifications'

### DIFF
--- a/content/pages/about/_index.md
+++ b/content/pages/about/_index.md
@@ -17,7 +17,7 @@ Dropdown_menu_elem_name_4: Standards Process
 Dropdown_menu_elem_url_4: standards-process
 Dropdown_menu_elem_name_5: The XSF
 Dropdown_menu_elem_url_5: xmpp-standards-foundation
-Dropdown_menu_elem_name_6: Extensions
+Dropdown_menu_elem_name_6: Specifications
 Dropdown_menu_elem_url_6: ../extensions
 Dropdown_menu_elem_name_7: FAQ
 Dropdown_menu_elem_url_7: faq
@@ -34,7 +34,7 @@ Sidebar_menu_elem_name_4: Standards Process
 Sidebar_menu_elem_url_4: about/standards-process
 Sidebar_menu_elem_name_5: The XSF
 Sidebar_menu_elem_url_5: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_6: Extensions
+Sidebar_menu_elem_name_6: Specifications
 Sidebar_menu_elem_url_6: extensions
 Sidebar_menu_elem_name_7: FAQ
 Sidebar_menu_elem_url_7: about/faq

--- a/content/pages/about/faq.md
+++ b/content/pages/about/faq.md
@@ -22,7 +22,7 @@ Sidebar_menu_elem_name_5: Standards Process
 Sidebar_menu_elem_url_5: about/standards-process
 Sidebar_menu_elem_name_6: The XSF
 Sidebar_menu_elem_url_6: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_7: Extensions
+Sidebar_menu_elem_name_7: Specifications
 Sidebar_menu_elem_url_7: extensions/index
 Sidebar_menu_elem_name_8: FAQ
 Sidebar_menu_elem_url_8: about/faq

--- a/content/pages/about/standards-process.md
+++ b/content/pages/about/standards-process.md
@@ -20,7 +20,7 @@ Sidebar_menu_elem_name_4: Standards Process
 Sidebar_menu_elem_url_4: about/standards-process
 Sidebar_menu_elem_name_5: The XSF
 Sidebar_menu_elem_url_5: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_6: Extensions
+Sidebar_menu_elem_name_6: Specifications
 Sidebar_menu_elem_url_6: extensions/index
 Sidebar_menu_elem_name_7: FAQ
 Sidebar_menu_elem_url_7: about/faq

--- a/content/pages/about/technology-overview.md
+++ b/content/pages/about/technology-overview.md
@@ -20,7 +20,7 @@ Sidebar_menu_elem_name_4: Standards Process
 Sidebar_menu_elem_url_4: about/standards-process
 Sidebar_menu_elem_name_5: The XSF
 Sidebar_menu_elem_url_5: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_6: Extensions
+Sidebar_menu_elem_name_6: Specifications
 Sidebar_menu_elem_url_6: extensions/index
 Sidebar_menu_elem_name_7: FAQ
 Sidebar_menu_elem_url_7: about/faq

--- a/content/pages/about/who-uses-xmpp.md
+++ b/content/pages/about/who-uses-xmpp.md
@@ -20,7 +20,7 @@ Sidebar_menu_elem_name_4: Standards Process
 Sidebar_menu_elem_url_4: about/standards-process
 Sidebar_menu_elem_name_5: The XSF
 Sidebar_menu_elem_url_5: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_6: Extensions
+Sidebar_menu_elem_name_6: Specifications
 Sidebar_menu_elem_url_6: extensions/index
 Sidebar_menu_elem_name_7: FAQ
 Sidebar_menu_elem_url_7: about/faq

--- a/content/pages/extensions.html
+++ b/content/pages/extensions.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>Extensions</title>
+    <title>Specifications</title>
     <meta name="url" content="extensions"/>
     <meta name="save_as" content="extensions/index.html"/>
 
@@ -30,7 +30,7 @@
     <meta name="sidebar_menu_elem_url_3" content="about/who-uses-xmpp"/>
     <meta name="sidebar_menu_elem_name_4" content="Standards Process"/>
     <meta name="sidebar_menu_elem_url_4" content="about/standards-process"/>
-    <meta name="sidebar_menu_elem_name_5" content="Extensions"/>
+    <meta name="sidebar_menu_elem_name_5" content="Specifications"/>
     <meta name="sidebar_menu_elem_url_5" content="extensions"/>
     <meta name="sidebar_menu_elem_name_6" content="The XSF"/>
     <meta name="sidebar_menu_elem_url_6" content="about/xmpp-standards-foundation"/>


### PR DESCRIPTION
The page currently titled 'extensions' is also the only page that lists the
RFCs. It is counterintuitive to have to navigate to a page named 'extensions'
to find the original RFCs.

This commit aims to apply changes only to the visual labels of the pages and
menu's. It explicitly does not change any paths, which should allow for existing
links, as well as the buildscript (which populates the table on this page) to
continue to work.