### PR TITLE
Replaced the Go library

### DIFF
--- a/content/pages/software/libraries.md
+++ b/content/pages/software/libraries.md
@@ -44,7 +44,7 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [exmpp](http://exmpp.org)                                                 | Erlang                              |                  |
 | [frabjous](https://github.com/theozaurus/frabjous)                        | JavaScript                          |                  |
 | [gloox](http://camaya.net)                                                | C++                                 |                  |
-| [goexmpp](https://code.google.com/archive/p/goexmpp)                      | Go                                  |                  |
+| [go-xmpp2](https://cjones.org/hg/go-xmpp2)                                | Go                                  | BSD              |
 | [headstock](https://github.com/Lawouach/headstock)                        | Python                              |                  |
 | [hsxmpp](http://חנוך.se)                                                  | Haskell                             |                  |
 | [hxmpp](http://hxmpp.disktree.net)                                        | haXe                                |                  |


### PR DESCRIPTION
The current Go library is marked as deprecated. I updated the table to point to the one referenced in the deprecation notice.