### PR TITLE
libraries: remove go-xmpp2

### DIFF
--- a/content/pages/software/libraries.md
+++ b/content/pages/software/libraries.md
@@ -45,7 +45,6 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [exmpp](http://exmpp.org)                                                 | Erlang                              |
 | [frabjous](https://github.com/theozaurus/frabjous)                        | JavaScript                          |
 | [gloox](http://camaya.net)                                                | C++                                 |
-| [go-xmpp2](https://cjones.org/hg/go-xmpp2)                                | Go                                  |
 | [headstock](https://github.com/Lawouach/headstock)                        | Python                              |
 | [hsxmpp](http://חנוך.se)                                                  | Haskell                             |
 | [hxmpp](http://hxmpp.disktree.net)                                        | haXe                                |


### PR DESCRIPTION
It is unmaintained and not actually compatible with any of the standard
Go tooling.

That being said, it probably does work; is that enough for us to list it?