### PR TITLE
Clients that are not available anymore

### DIFF
--- a/content/pages/software/clients.md
+++ b/content/pages/software/clients.md
@@ -31,7 +31,6 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [Adium](http://adium.im)                          | OSX                                                |
 | [AQQ](http://aqq.eu)                            | Windows                                            |
 | [AstraChat](http://astrachat.com)                      | Mobile (Android, iOS) / Linux / OSX / Windows                            |
-| [beejive](http://beejive.com)                        | Mobile (Android, BlackBerry, iOS)                  |
 | [Beem](http://beem-project.com)                           | Mobile (Android)                                   |
 | [BitlBee](http://bitlbee.org)                        | Linux                                              |
 | [BlueJabb](http://bluejabb.com)                       | Mobile (Android, Blackberry (BBOS), Nokia Symbian S40/S60 and Asha)      |
@@ -41,9 +40,8 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [Conversations](https://github.com/siacs/Conversations)                  | Mobile (Android)              |
 | [Converse.js](http://conversejs.org)                    | Browser                                                |
 | [Coversant SoapBox Communicator](http://coversant.com) | Windows                                                |
-| [Crosstalk](http://portablek.com)                      | Mobile (iOS)                                           |
 | [eM Client](http://emclient.com)                      | Windows                                                |
-| [Empathy](http://live.gnome.org)                        | Linux                                                  |
+| [Empathy](https://wiki.gnome.org/Apps/Empathy)                        | Linux                                                  |
 | [Finch](http://developer.pidgin.im)                          | Console / Text-Mode                                 |
 | [Gajim](http://gajim.org)                          | Linux / Windows                                        |
 | [ChatSecure](http://guardianproject.info)                     | Mobile (Android)                                  |
@@ -55,7 +53,6 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [irssi-xmpp](http://cybione.org)                     | Console / Text-Mode                                    |
 | [jabber.el](http://emacs-jabber.sourceforge.net)                      | Linux                             |
 | [Jabbim](http://jabbim.com)                         | Linux / OSX / Windows                                  |
-| [Jabiru](http://jabiru.info)                         | Mobile (Android)                                       |
 | [JAJC](http://jajc.jrudevels.org)                           | Windows                                                |
 | [Jappix](http://jappix.org)                         | Browser                                                |
 | [Jitsi](http://jitsi.org)       | Linux / OSX / Windows                                               |
@@ -80,21 +77,20 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [qutIM](http://qutim.org)                          | Linux / OSX / Windows                                  |
 | [Salut à Toi](https://salut-a-toi.org/)             | Linux / Console / Text-Mode / Browser                  |
 | [Sim-IM](http://sim-im.org)                         | Linux                                                  |
-| [Spark](http://igniterealtime.org)                          | Linux / OSX / Windows                                  |
-| [SparkWeb](http://igniterealtime.org)                       | Browser                                                |
+| [Spark](https://igniterealtime.org/projects/spark/index.jsp)                          | Linux / OSX / Windows                                  |
+| [SparkWeb](https://igniterealtime.org/projects/sparkweb/index.jsp)                       | Browser                                                |
 | [Swift](http://swift.im)                          | Linux / OSX / Windows                                  |
 | [Talkonaut](http://talkonaut.com)                      | Mobile                                                 |
-| [Tigase Messenger](http://tigase.org)               | Browser                                                |
+| [Tigase Messenger](http://www.tigase.net/content/tigase-messenger-android)               | Browser                                                |
 | [Tigase Minichat](http://tigase.org)                | Browser                                                |
 | [Tkabber](http://tkabber.jabber.ru)                        | Linux / OSX / Windows                                  |
 | [Trillian](http://trillian.im)                       | Windows/ OSX / Mobile / Browser                        |
-| [V&V Messenger](http://altertech.net)                  | Windows                                                |
-| [Vacuum-IM](http://vacuum-im.org)                      | Linux / OSX / Windows                                  |
+| [V&V Messenger](http://www.altertech.com/products/vv/)                  | Windows                                                |
 | [Vayusphere](http://vayusphere.com)                     | Mobile (BlackBerry)                                    |
-| [VSTalk](http://codeplex.com)                         | Windows                                                |
-| [WTW](http://k2t.eu)                            | Windows                                                |
+| [VSTalk](https://vstalk.codeplex.com/)                         | Windows                                                |
+| [WTW](http://wtw.im/)                            | Windows                                                |
 | [Xabber](http://xabber.com)                         | Mobile (Android)                                       |
 | [xmpp-client](https://github.com/agl/xmpp-client) | Linux / OSX |
 | [xmppchat](http://babelmonkeys.de)                       | Browser                                                |
-| [XMPPWebChat](http://code.google.com)                    | Browser                                                |
+| [XMPPWebChat](https://github.com/udayg/xmppwebchat)                    | Browser                                                |
 | [yaxim](http://yaxim.org)                          | Mobile (Android)                                       |

--- a/content/pages/software/clients.md
+++ b/content/pages/software/clients.md
@@ -93,4 +93,4 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [xmpp-client](https://github.com/agl/xmpp-client) | Linux / OSX |
 | [xmppchat](http://babelmonkeys.de)                       | Browser                                                |
 | [XMPPWebChat](https://github.com/udayg/xmppwebchat)                    | Browser                                                |
-| [yaxim](http://yaxim.org)                          | Mobile (Android)                                       |
+| [yaxim](https://yaxim.org)                          | Mobile (Android)                                       |

--- a/content/pages/software/clients.md
+++ b/content/pages/software/clients.md
@@ -68,7 +68,7 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [Mozilla Thunderbird](http://mozilla.org/thunderbird)            | Linux / OSX / Windows                       |
 | [OneTeam](http://oneteam.im)                        | Linux / OSX / Windows                                  |
 | [OneTeam for iPhone](http://oneteam.im)             | Mobile (iOS)                                           |
-| [Poezio](http://poez.io)                           | Console / Text-Mode                                    |
+| [Poezio](https://poez.io)                           | Console / Text-Mode                                    |
 | [Pidgin](http://pidgin.im)                         | Linux / OSX / Windows                                  |
 | [Profanity](http://profanity.im)                      | Console / Text-Mode                                    |
 | [Psi](http://psi-im.org)                            | Linux / OSX / Windows                                  |


### PR DESCRIPTION
* Beejive website does not respond, app removed from AppStore http://downforeveryoneorjustme.com/beejive.com
* Coversant http://downforeveryoneorjustme.com/coversant.com
* Crosstalk/portablek http://downforeveryoneorjustme.com/portablek.com
* Jabiru: https://play.google.com/store/apps/details?id=net.mzet.jabiru "discontinued" and domain name available
* vacuum-im http://downforeveryoneorjustme.com/vacuum-im.org
* Links update: Empathy, Spark, SparkWeb, Tigase Messenger, VSTalk, WTW, XMPPWebChat (https://code.google.com/archive/p/xmppwebchat/)