### PR TITLE
libraries: update Loudmouth information

### DIFF
--- a/content/pages/software/libraries.md
+++ b/content/pages/software/libraries.md
@@ -62,8 +62,7 @@ __See something missing?__ Any list of XMPP servers, clients or libraries will, 
 | [libstrophe](http://strophe.im)                                           | C                                   |
 | [libpurple](https://developer.pidgin.im/wiki/WhatIsLibpurple)             | C/C++                               |
 | [Lightr](https://github.com/myYearbook/lightr)                            | PHP                                 |
-| Loudmouth                                                                 | C                                   |
-| Loudmouth                                                                 | Ruby                                |
+| [Loudmouth](https://github.com/mcabber/loudmouth)                         | C                                   |
 | [MatriX](http://ag-software.net)                                          | C# / .net) / Mono                   |
 | net::XMPP                                                                 | Perl                                |
 | [node-xmpp](http://node-xmpp.org)                                         | JavaScript                          |


### PR DESCRIPTION
Updated the C library which is now being maintained by the MCabber community and removed the Ruby bindings that are unmaintained.

Note, I'm the original author but @McKael is currently the maintainer.