### PR TITLE
Update link to Apache Vysper

### DIFF
--- a/content/pages/software/servers.md
+++ b/content/pages/software/servers.md
@@ -25,31 +25,32 @@ An XMPP server provides basic messaging, presence, and XML routing features. Thi
 
 __See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If you spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org)
 
-| Name                                                 | Platform(s)                          |
-|------------------------------------------------------|--------------------------------------|
-| [Apache Vysper](http://mina.apache.org)              | Windows / Linux                      |
-| [Citadel](http://citadel.org)                        | Linux                                |
-| [CommuniGate Pro](http://communigate.com)            | Linux / Mac OS X / Windows           |
-| [Coversant SoapBox Server](http://coversant.com)     | Windows                              |
-| [djabberd](http://danga.com)                         | Linux                                |
-| [ejabberd](http://process-one.net)                   | Linux / Mac OS X / Solaris / Windows |
-| [IceWarp](http://icewarp.com)                        | Linux / Windows                      |
-| [iChat Server](http://apple.com)                     | Mac OS X                             |
-| [in.jabberd](http://inetdxtra.sourceforge.net)       | Linux                                |
-| [Isode M-Link](http://isode.com)                     | Linux / Solaris / Windows            |
-| [Jabber XCP](http://cisco.com)                       | Linux / Solaris / Windows            |
-| [jabberd 1.x](http://jabberd.org)                    | Linux                                |
-| [jabberd 2.x](http://jabberd2.org)                   | Linux / *BSD / Solaris / Windows     |
-| [Jerry Messenger](http://j-livesupport.com)          | Linux / Windows                      |
-| [Kwickserver](http://kwickserver.info)               | Windows                              |
-| [Metronome IM](http://lightwitch.org/metronome)      | Linux / Mac OS X                     |
-| [MongooseIM](http://erlang-solutions.com)            | Linux / Mac OS X                     |
-| [Openfire](http://igniterealtime.org)                | Linux / Mac OS X / Solaris / Windows |
-| [Oracle Communications IM Server](http://oracle.com) | Linux / Solaris / Windows            |
-| [Prosody IM](http://prosody.im)                      | Linux / Mac OS X / Windows           |
-| [psyced](http://psyced.org)                          | Linux / Mac OS X / Windows           |
-| [Siemens OpenScape](http://siemens-enterprise.com)   | Linux                                |
-| [Tigase](http://tigase.org)                          | Linux / Solaris / Mac OS X / Windows |
-| [Vines](http://getvines.com)                         | Linux / Mac OS X                     |
-| [Wokkel](http://wokkel.ik.nu)                        | Linux / Solaris / Mac OS X           |
+| Name                                                    | Platform(s)                          |
+|---------------------------------------------------------|--------------------------------------|
+| [Apache Vysper](https://mina.apache.org/vysper-project) | Windows / Linux                      |
+| [Citadel](http://citadel.org)                           | Linux                                |
+| [CommuniGate Pro](http://communigate.com)               | Linux / Mac OS X / Windows           |
+| [Coversant SoapBox Server](http://coversant.com)        | Windows                              |
+| [djabberd](http://danga.com)                            | Linux                                |
+| [ejabberd](http://process-one.net)                      | Linux / Mac OS X / Solaris / Windows |
+| [IceWarp](http://icewarp.com)                           | Linux / Windows                      |
+| [iChat Server](http://apple.com)                        | Mac OS X                             |
+| [in.jabberd](http://inetdxtra.sourceforge.net)          | Linux                                |
+| [Isode M-Link](http://isode.com)                        | Linux / Solaris / Windows            |
+| [Jabber XCP](http://cisco.com)                          | Linux / Solaris / Windows            |
+| [jabberd 1.x](http://jabberd.org)                       | Linux                                |
+| [jabberd 2.x](http://jabberd2.org)                      | Linux / *BSD / Solaris / Windows     |
+| [Jerry Messenger](http://j-livesupport.com)             | Linux / Windows                      |
+| [Kwickserver](http://kwickserver.info)                  | Windows                              |
+| [Metronome IM](http://lightwitch.org/metronome)         | Linux / Mac OS X                     |
+| [MongooseIM](http://erlang-solutions.com)               | Linux / Mac OS X                     |
+| [Openfire](http://igniterealtime.org)                   | Linux / Mac OS X / Solaris / Windows |
+| [Oracle Communications IM Server](http://oracle.com)    | Linux / Solaris / Windows            |
+| [Prosody IM](http://prosody.im)                         | Linux / Mac OS X / Windows           |
+| [psyced](http://psyced.org)                             | Linux / Mac OS X / Windows           |
+| [Siemens OpenScape](http://siemens-enterprise.com)      | Linux                                |
+| [Tigase](http://tigase.org)                             | Linux / Solaris / Mac OS X / Windows |
+| [Vines](http://getvines.com)                            | Linux / Mac OS X                     |
+| [Wokkel](http://wokkel.ik.nu)                           | Linux / Solaris / Mac OS X           |
+
 


### PR DESCRIPTION
Updated the Apache Vysper link to point directly to the Vysper page within its enclosing project (MINA).

Other rows in the table were only updated with padding to align columns.