### PR TITLE
Remove link to non-existent all.shtml

### DIFF
--- a/content/pages/extensions.html
+++ b/content/pages/extensions.html
@@ -54,9 +54,8 @@
             <a href='https://datatracker.ietf.org/doc/rfc7395/'>RFC 7395</a>).
         </p>
         <p>
-            The XMPP Standards Foundation develops extensions to XMPP in its XEP series. This page lists Draft and Final XEPs as well as experimental proposals that are currently under consideration. A 
-            <a href="http://xmpp.org/extensions/all.shtml">list of all XEPs</a> 
-            (including retracted, rejected, deprecated, and obsolete XEPs) is also available. Good places for developers to start are the 
+            The XMPP Standards Foundation develops extensions to XMPP in its XEP series. This page lists Draft and Final XEPs as well as experimental proposals that are currently under consideration.
+            Good places for developers to start are the 
             <a href="http://xmpp.org/extensions/xep-0242.html">client compliance</a> and 
             <a href="http://xmpp.org/extensions/xep-0243.html">server compliance</a> definitions, as well as the 
             <a href="http://xmpp.org/about-xmpp/technology-overview/">technology overview pages</a>.


### PR DESCRIPTION
> A [list of all XEPs](http://xmpp.org/extensions/all.shtml) (including retracted, rejected, deprecated, and obsolete XEPs) is also available.

This text is wrong, since extensions.html lists all those XEPs already, depending on the checkboxes.