### PR TITLE
Website should have a 'getting started' page

### DIFF
--- a/content/pages/uses/getting-started.md
+++ b/content/pages/uses/getting-started.md
@@ -1,0 +1,34 @@
+---
+Title: Getting Started
+Url: uses/getting-started
+Save_as: uses/getting-started.html
+Top_menu_show: true
+Top_Menu_order: 6
+Dropdown_menu_show: false
+Footer_show: false
+Content_layout: multiple-columns
+---
+
+Do you want to start chatting with XMPP? This page helps you get up and running in a matter of minutes.
+
+# 1. Download a client
+
+There are [many, many XMPP clients](/software/clients) for you to choose from. To get you started, here are some of the more popular ones:
+
+* [Conversations](https://play.google.com/store/apps/details?id=eu.siacs.conversations&referrer=utm_source%3Dxmpp.org) (Android)
+* [Swift.IM](http://swift.im/swift.html) (OS X, Windows & Linux)
+* [Lorem ipsum](http://example.org)
+* [Dolor sit amet](http://example.org)
+
+# 2. Create an account
+
+As with e-mail, you'll need an account with a service provider. Again, there are [plenty of choices](https://xmpp.net/directory.php), from which these are only a couple of the more popular ones:
+
+* [Lorem ipsum](http://example.org)
+* [Dolor sit amet](http://example.org)
+* [Something like four](http://example.org)
+* [choices would do](http://example.org)
+
+# 3. Log in! That's it!
+
+Using your client, log in and start adding your friends, or visit one of the many chatrooms!

--- a/content/pages/uses/getting-started.md
+++ b/content/pages/uses/getting-started.md
@@ -24,10 +24,10 @@ There are [many, many XMPP clients](/software/clients) for you to choose from. T
 
 As with e-mail, you'll need an account with a service provider. Again, there are [plenty of choices](https://xmpp.net/directory.php), from which these are only a couple of the more popular ones:
 
+* [xmpp.jp](https://www.xmpp.jp/signup)
+* [jabber.ru](https://jabber.ru/user/register)
 * [Lorem ipsum](http://example.org)
 * [Dolor sit amet](http://example.org)
-* [Something like four](http://example.org)
-* [choices would do](http://example.org)
 
 # 3. Log in! That's it!
 

--- a/content/pages/uses/getting-started.md
+++ b/content/pages/uses/getting-started.md
@@ -17,8 +17,9 @@ There are [many, many XMPP clients](/software/clients) for you to choose from. T
 
 * [Conversations](https://play.google.com/store/apps/details?id=eu.siacs.conversations&referrer=utm_source%3Dxmpp.org) (Android)
 * [Swift.IM](http://swift.im/swift.html) (OS X, Windows & Linux)
-* [Lorem ipsum](http://example.org)
-* [Dolor sit amet](http://example.org)
+* [Gajim](https://gajim.org/) (Windows & Linux)
+* [Adium](https://adium.im/) (OS X)
+* [Pidgin](http://pidgin.im/) (OS X, Windows & Linux)
 
 # 2. Create an account
 
@@ -26,8 +27,8 @@ As with e-mail, you'll need an account with a service provider. Again, there are
 
 * [xmpp.jp](https://www.xmpp.jp/signup)
 * [jabber.ru](https://jabber.ru/user/register)
-* [Lorem ipsum](http://example.org)
-* [Dolor sit amet](http://example.org)
+* [JWChat](https://accounts.jwchat.org/)
+* [jabber.at](https://jabber.at/account/register/)
 
 # 3. Log in! That's it!
 


### PR DESCRIPTION
This pull request introduces a new page that guides people that are completely new to XMPP.

This pull request results from a discussion on the XSF MUC earlier today. I thought it'd be a good idea to float the idea in a tangible way. Obviously, the commit needs work: the list of clients and services needs to be completed, and the entire thing could be made a lot prettier too.