### PR TITLE
Adding categories to blog.

### DIFF
--- a/content/posts/blog/19th-xmpp-summit-and-fosdem-2016.md
+++ b/content/posts/blog/19th-xmpp-summit-and-fosdem-2016.md
@@ -3,6 +3,7 @@ title: The 19th XMPP Summit and FOSDEM 2016
 date: 2016-02-08 22:25
 authors: Tobi; Nyco
 blog_id: blog
+category: XMPP Summit
 ---
 
 ##19th XMPP Summit

--- a/content/posts/blog/2011-q4-membership-application-period-has-started.md
+++ b/content/posts/blog/2011-q4-membership-application-period-has-started.md
@@ -3,6 +3,7 @@ title: 2011 Q4 Membership Application Period has started
 date: 2011-09-22 21:47
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 Alexander Gnauck has announced to the members@xmpp.org mailing list that the [membership application Wiki page](http://wiki.xmpp.org/web/Membership_Applications_Q4_2011) for the next application period is ready.  Now is the time to start looking for new members, or remind those who have dropped to reapply.

--- a/content/posts/blog/2013-annual-meeting-and-voting-results.md
+++ b/content/posts/blog/2013-annual-meeting-and-voting-results.md
@@ -3,6 +3,7 @@ title: 2013 Annual Meeting and Voting Results
 date: 2013-11-07 16:01
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 Every year the members of the XSF get together to vote on the current quarter's new and renewing members and to also elect who will become members of the Technical Council and who will server on the Board of Directors.

--- a/content/posts/blog/2013-q1-membership-voting-is-happening-now.md
+++ b/content/posts/blog/2013-q1-membership-voting-is-happening-now.md
@@ -3,6 +3,7 @@ title: 2013 Q1 Membership Voting is happening now!
 date: 2013-04-25 02:44
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 Alex has started the membership voting process (big shout-out and thanks to Lance for getting the bot updated!) and would love it if all the current members chat with the [memberbot](%20xmpp:memberbot@xmpp.org) and vote on the [2013 Q1 membership applications](http://wiki.xmpp.org/web/Membership_Applications_Q1_2013).

--- a/content/posts/blog/2013-xsf-board-and-tech-council.md
+++ b/content/posts/blog/2013-xsf-board-and-tech-council.md
@@ -3,6 +3,7 @@ title: 2013 XSF Board and Tech Council
 date: 2012-12-07 02:57
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 At the last annual meeting (and yes, we are rather late reporting this) the results of the vote as gathered and tabulated:

--- a/content/posts/blog/and-our-gsoc-students-are.md
+++ b/content/posts/blog/and-our-gsoc-students-are.md
@@ -3,6 +3,7 @@ title: And our GSoC students are...
 date: 2012-04-29 11:17
 author: florian
 blog_id: blog
+category: Google Summer of Code
 ---
 
 It's with great pleasure that we would like to share with you the list of students that have been selected to participate in the Google Summer of Code 2012 for the XMPP Standards Foundation.

--- a/content/posts/blog/annual-meeting-summary.md
+++ b/content/posts/blog/annual-meeting-summary.md
@@ -3,6 +3,7 @@ title: Annual Meeting Summary
 date: 2010-11-03 09:40
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 XSF Member Jehan posted this summary to the members mailing list:

--- a/content/posts/blog/annual-report.md
+++ b/content/posts/blog/annual-report.md
@@ -3,6 +3,7 @@ title: Annual Report
 date: 2008-03-18 19:16
 author: stpeter
 blog_id: blog
+category: XSF Organisational
 ---
 
 Regrettably, the XSF has not issued an annual report since 2002. It seems we're always too busy getting things done to report on our activities. But this year we decided to turn over a new leaf by completing an annual report, available at [http://www.xmpp.org/xsf/docs/annual-report-2007.shtml](http://www.xmpp.org/xsf/docs/annual-report-2007.shtml).

--- a/content/posts/blog/another-summer-of-code.md
+++ b/content/posts/blog/another-summer-of-code.md
@@ -3,6 +3,7 @@ title: Another Summer of Code
 date: 2012-03-21 10:46
 author: stpeter
 blog_id: blog
+category: Google Summer of Code
 ---
 
 We're happy to announce that the XSF has been accepted to participate in the Google Summer of Code for 2012. See our [wiki page](http://wiki.xmpp.org/web/Summer_of_Code_2012) for details. We still have time to add project ideas to the list there, so if you participate in an XMPP-related codebase feel free to get involved!

--- a/content/posts/blog/board-and-council-elections-2010.md
+++ b/content/posts/blog/board-and-council-elections-2010.md
@@ -3,6 +3,7 @@ title: Board and Council Elections 2010
 date: 2010-09-28 08:43
 author: willsheward
 blog_id: blog
+category: XSF Organisational
 ---
 
 In accordance with the [XSF Bylaws](http://xmpp.org/about-xmpp/xsf/xsf-bylaws/), once a year the XMPP Standards Foundation holds elections for its [Board of Directors](http://xmpp.org/about-xmpp/xsf/the-xsf-board-of-directors/) and for the [XMPP Council](http://xmpp.org/about-xmpp/xsf/the-xsf-council/). Elections for the 2010-2011 Board and Council will be held on October 25, 2010 (with proxy voting 1 Oct. - 24 Oct.).

--- a/content/posts/blog/board-and-council-elections.md
+++ b/content/posts/blog/board-and-council-elections.md
@@ -3,6 +3,7 @@ title: Board and Council Elections
 date: 2009-09-01 11:58
 author: stpeter
 blog_id: blog
+category: XSF Organisational
 ---
 
 Once a year, the XMPP Standards Foundation holds elections for its [Board of Directors](http://xmpp.org/xsf/board/) and for the [XMPP Council](http://xmpp.org/council/). That time is now, so the XSF is actively soliciting people to stand for election. Here is the division of responsibilities between the two groups:

--- a/content/posts/blog/board-goals-for-2015.md
+++ b/content/posts/blog/board-goals-for-2015.md
@@ -3,6 +3,7 @@ title: Board goals for 2015
 date: 2015-03-23 04:51
 author: laura
 blog_id: blog
+category: XSF Organisational
 ---
 
 When our newest Board of Directors were elected, they decided that they wanted to set some goals against which their achievements as Board members could be measured.

--- a/content/posts/blog/brussels-report.md
+++ b/content/posts/blog/brussels-report.md
@@ -3,6 +3,7 @@ title: Brussels Report
 date: 2007-02-27 20:14
 author: stpeter
 blog_id: blog
+category: XMPP Summit
 ---
 
 Over the weekend, members of the XMPP Standards Foundation and the Jabber developer community participated in [FOSDEM 2007](http://www.fosdem.org/) (one of the world's premier conferences for developers of free and open-source software) and also held a smaller "XMPP Summit" to discuss high-priority issues related to our technology.

--- a/content/posts/blog/brussels-trip-report.md
+++ b/content/posts/blog/brussels-trip-report.md
@@ -3,6 +3,7 @@ title: Brussels Trip Report
 date: 2011-02-18 16:38
 author: stpeter
 blog_id: blog
+category: XMPP Summit
 ---
 
 Once again the XMPP community came together recently in Brussels to discuss XMPP technologies at the [XMPP Summit](http://xmpp.org/participate/the-xmpp-summit/xmpp-summit-10/) and to evangelize at the [Free and Open Source Software Developers' European Meeting](http://fosdem.org/) (FOSDEM). Here is a brief "trip report" from yours truly, XSF executive director Peter Saint-Andre.

--- a/content/posts/blog/elections.md
+++ b/content/posts/blog/elections.md
@@ -3,6 +3,7 @@ title: Elections
 date: 2007-08-15 15:50
 author: stpeter
 blog_id: blog
+category: XSF Organisational
 ---
 
 Every year is an election for the [XMPP Standards Foundation](http://www.xmpp.org/), because since 2001 we have elected a new [XMPP Council](http://www.xmpp.org/council) (our technical leadership team) and a new [Board of Directors](http://www.xmpp.org/xsf/board/) (our business leadership team) in late August or September.

--- a/content/posts/blog/fosdem-2012-report.md
+++ b/content/posts/blog/fosdem-2012-report.md
@@ -3,6 +3,7 @@ title: FOSDEM 2012 Report
 date: 2012-03-14 12:30
 author: stpeter
 blog_id: blog
+category: FOSDEM
 ---
 
 On February 3-6, the XSF and members of the XMPP community participated in both XMPP Summit 11 and FOSDEM 2012 in Brussels, Belgium. This is a late report about the activities there, based on the notes made at the time about the [Summit](http://mail.jabber.org/pipermail/summit/2012-February/001084.html) and [FOSDEM](http://mail.jabber.org/pipermail/members/2012-February/006679.html) in general.

--- a/content/posts/blog/fosdem-and-summit-report.md
+++ b/content/posts/blog/fosdem-and-summit-report.md
@@ -3,6 +3,7 @@ title: FOSDEM and Summit Report
 date: 2010-02-10 12:28
 author: stpeter
 blog_id: blog
+category: XMPP Summit
 ---
 
 The XSF held another successful [XMPP Summit](http://xmpp.org/summit/summit8.shtml) over the weekend at [FOSDEM 2010](http://fosdem.org/2010/) in Brussels, Belgium. Many thanks to the companies who sponsored this event: [Nokia](http://www.nokia.com/), [Vodafone](http://www.vodafone.com), [Collabora](http://collabora.co.uk/), [Isode](http://www.isode.com/), [TANDBERG](http://www.tandberg.com/), [Buddycloud](http://www.buddycloud.com/), [Collecta](http://collecta.com/), and [Ooros](http://www.ooros.com/). Special thanks to Nokia for temporarily donating some N900 devices for the Developer Challenge, and to [Mobile Vikings](http://mobilevikings.com/) for the SIM cards that enabled a number of XMPP developers to experiment with building mobile applications at the conference. And extra special thanks to XSF Board member Florian Jensen for his hard work on local coordination (as well as the photos in this blog post).

--- a/content/posts/blog/fosdem-day-1.md
+++ b/content/posts/blog/fosdem-day-1.md
@@ -3,6 +3,7 @@ title: FOSDEM Day 1
 date: 2009-02-08 01:42
 author: willsheward
 blog_id: blog
+category: FOSDEM
 ---
 
 A quick report from day 1 of FOSDEM. The Dev room was packed for virtually every session (standing room only as you can see from a selection of pictures below) and every talk, despite problems with the FOSDEM wi-fi, was well received.

--- a/content/posts/blog/fosdem-podcast-dave-cridland-2.md
+++ b/content/posts/blog/fosdem-podcast-dave-cridland-2.md
@@ -3,6 +3,7 @@ title: FOSDEM podcast: Dave Cridland
 date: 2010-06-08 12:00
 author: Nyco
 blog_id: blog
+category: FOSDEM
 ---
 
 This is the second in a series of podcasts made at FOSDEM in Brussels, Belgium.

--- a/content/posts/blog/fosdem-podcast-fabio-forno-2.md
+++ b/content/posts/blog/fosdem-podcast-fabio-forno-2.md
@@ -3,6 +3,7 @@ title: FOSDEM podcast: Fabio Forno
 date: 2010-06-07 12:00
 author: Nyco
 blog_id: blog
+category: FOSDEM
 ---
 
 This is the first in a series of podcasts made at FOSDEM in Brussels, Belgium.

--- a/content/posts/blog/fosdem-podcast-florian-jensen-2.md
+++ b/content/posts/blog/fosdem-podcast-florian-jensen-2.md
@@ -3,6 +3,7 @@ title: FOSDEM podcast: Florian Jensen
 date: 2010-06-09 12:00
 author: Nyco
 blog_id: blog
+category: FOSDEM
 ---
 
 This is the third in a series of podcasts made at FOSDEM in Brussels, Belgium.

--- a/content/posts/blog/fosdem-podcast-simon-tennant-2.md
+++ b/content/posts/blog/fosdem-podcast-simon-tennant-2.md
@@ -3,6 +3,7 @@ title: FOSDEM podcast: Simon Tennant
 date: 2010-06-11 12:00
 author: Nyco
 blog_id: blog
+category: FOSDEM
 ---
 
 This is the fourth and last in a series of podcasts made at FOSDEM in Brussels, Belgium.

--- a/content/posts/blog/google-summer-of-code-2008.md
+++ b/content/posts/blog/google-summer-of-code-2008.md
@@ -3,6 +3,7 @@ title: Google Summer of Code 2008
 date: 2008-04-21 12:39
 author: stpeter
 blog_id: blog
+category: Google Summer of Code
 ---
 
 For the fourth year in a row, the [XMPP Standards Foundation](http://www.xmpp.org/xsf/) is [participating](http://code.google.com/soc/2008/xmpp/about.html) in the [Google Summer of Code](http://code.google.com/soc/2008/). Our projects for 2008 are as follows:

--- a/content/posts/blog/google-summer-of-code-2011-project-ideas.md
+++ b/content/posts/blog/google-summer-of-code-2011-project-ideas.md
@@ -3,6 +3,7 @@ title: Google Summer of Code 2011 - Project Ideas
 date: 2011-02-28 08:49
 author: bear
 blog_id: blog
+category: Google Summer of Code
 ---
 
 Today I will be applying to the Google's [Summer of Code 2011](http://code.google.com/soc/) on behalf of the [XSF](http://xmpp.org/) - woo! The one thing that always makes it easy for Google to pick an organization is a large list of projects and students interested in our projects.

--- a/content/posts/blog/google-summer-of-code-2011-we-are-in.md
+++ b/content/posts/blog/google-summer-of-code-2011-we-are-in.md
@@ -3,6 +3,7 @@ title: Google Summer of Code 2011 - we are in!
 date: 2011-03-18 14:52
 author: bear
 blog_id: blog
+category: Google Summer of Code
 ---
 
 The [XSF](http://xmpp.org/) has been invited to participate in Google's [Summer of Code 2011](http://code.google.com/soc/)! Great job by everyone in making our application something the Goog couldn't resist ;)

--- a/content/posts/blog/google-summer-of-code-2011.md
+++ b/content/posts/blog/google-summer-of-code-2011.md
@@ -3,6 +3,7 @@ title: Google Summer of Code 2011
 date: 2011-02-22 12:02
 author: bear
 blog_id: blog
+category: Google Summer of Code
 ---
 
 The [XSF](http://xmpp.org/) will be applying this year to participate in Google's [Summer of Code 2011](http://code.google.com/soc/) and we need the help of XMPP project members in getting a   list of summer project ideas together!

--- a/content/posts/blog/google-summer-of-code-2014.md
+++ b/content/posts/blog/google-summer-of-code-2014.md
@@ -3,6 +3,7 @@ title: Google Summer of Code 2014
 date: 2014-02-28 12:25
 author: laura
 blog_id: blog
+category: Google Summer of Code
 ---
 
 While the XSF may not be mentoring a project in this years [Google's Summer of Code 2014](http://code.google.com/soc/) -  we sure can celebrate and shout about the fact that some of the projects include XMPP as part of their project ideas!

--- a/content/posts/blog/google-summer-of-code-project-update.md
+++ b/content/posts/blog/google-summer-of-code-project-update.md
@@ -3,6 +3,7 @@ title: Google Summer of Code - Project Update
 date: 2010-04-29 02:30
 author: bear
 blog_id: blog
+category: Google Summer of Code
 ---
 
 As of 1900 UTC Monday, Google has published the list of accepted project for the Google Summer of Code and I'm very happy to report that four of the proposals to the XSF were accepted!

--- a/content/posts/blog/google-summer-of-code-update.md
+++ b/content/posts/blog/google-summer-of-code-update.md
@@ -3,6 +3,7 @@ title: Google Summer of Code Update
 date: 2010-07-16 08:39
 author: bear
 blog_id: blog
+category: Google Summer of Code
 ---
 
 The Mentor's and Students have all been working hard with their projects and they have reached an important milestone: the mid-term evaluations!  As of a couple hours ago all of our evaluations have been submitted and they are ready to continue on towards the last half of the project.

--- a/content/posts/blog/google-summer-of-code.md
+++ b/content/posts/blog/google-summer-of-code.md
@@ -3,6 +3,7 @@ title: Google Summer of Code
 date: 2009-02-26 20:33
 author: stpeter
 blog_id: blog
+category: Google Summer of Code
 ---
 
 At its meeting yesterday, the [XMPP Council](http://xmpp.org/council/) decided not to participate in the [Google Summer of Code](http://code.google.com/soc/) (GSoC) for 2009. There are several reasons for this decision:

--- a/content/posts/blog/gsoc-2012-student-application-deadline-approaching.md
+++ b/content/posts/blog/gsoc-2012-student-application-deadline-approaching.md
@@ -3,6 +3,7 @@ title: GSoC 2012 Student Application deadline approaching
 date: 2012-04-03 14:27
 author: florian
 blog_id: blog
+category: Google Summer of Code
 ---
 
 ![](http://code.google.com/images/GSoC2012_300x200.png "GSoC 2012")

--- a/content/posts/blog/gsoc-coding-has-begun.md
+++ b/content/posts/blog/gsoc-coding-has-begun.md
@@ -3,6 +3,7 @@ title: GSoC Coding Has Begun
 date: 2012-06-08 11:45
 author: stpeter
 blog_id: blog
+category: Google Summer of Code
 ---
 
 Our [Google Summer of Code students](/2012/04/and-our-gsoc-students-are/) are merrily coding away now.

--- a/content/posts/blog/gsoc-student-application-deadline-tomorrow.md
+++ b/content/posts/blog/gsoc-student-application-deadline-tomorrow.md
@@ -3,6 +3,7 @@ title: GSoC Student Application deadline tomorrow
 date: 2011-04-07 20:13
 author: bear
 blog_id: blog
+category: Google Summer of Code
 ---
 
 If you are a student submitting a project for the [XSF's GSoC 2011](http://www.google-melange.com/gsoc/org/google/gsoc2011/xsf) please remember that the deadline for submission is Fri, April 8, 12:00 – 13:00 (GMT).

--- a/content/posts/blog/gsoc-student-application-deadline.md
+++ b/content/posts/blog/gsoc-student-application-deadline.md
@@ -3,6 +3,7 @@ title: GSoC Student Application Deadline
 date: 2010-04-02 13:17
 author: bear
 blog_id: blog
+category: Google Summer of Code
 ---
 
 Just a reminder to folks (aka Students) that the deadline for Student Proposals is April 9th.

--- a/content/posts/blog/gsoc-update-11-apr-2010.md
+++ b/content/posts/blog/gsoc-update-11-apr-2010.md
@@ -3,6 +3,7 @@ title: GSoC Update 11 Apr 2010
 date: 2010-04-12 02:20
 author: bear
 blog_id: blog
+category: Google Summer of Code
 ---
 
 The deadline for Student Proposals has come and gone and the XSF has received quite a few proposals covering a wide range of topics, clients and servers!

--- a/content/posts/blog/gsoc09-with-xmpp.md
+++ b/content/posts/blog/gsoc09-with-xmpp.md
@@ -3,6 +3,7 @@ title: GSoC '09, with XMPP
 date: 2009-04-29 09:55
 author: Nyco
 blog_id: blog
+category: Google Summer of Code
 ---
 
 The XMPP Standards Foundation has helped support a number of open-source projects through Google's Summer of Code program over the years. Although the XSF is [not participating](http://blog.xmpp.org/index.php/2009/02/google-summer-of-code/) in the [Google Summer of Code](http://code.google.com/soc/) this year, a number of XMPP-related projects have been accepted by other mentoring organizations...

--- a/content/posts/blog/member-voting-last-call.md
+++ b/content/posts/blog/member-voting-last-call.md
@@ -3,6 +3,7 @@ title: Member Voting - last call!
 date: 2010-12-13 11:59
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 The proxy voting still has not reached a quorom, so unless you plan on voting at the meeting you have until the close of business on December 14th. On December 15th we will have one of the few required "all hands" meetings to formally approve the voting results.

--- a/content/posts/blog/membership-application-period-ending-soon.md
+++ b/content/posts/blog/membership-application-period-ending-soon.md
@@ -3,6 +3,7 @@ title: Membership Application period ending soon!
 date: 2010-11-22 13:57
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 The XMPP Standards Foundation is currently accepting applications for new members.

--- a/content/posts/blog/membership-application-period-for-q4-2013-has-begun.md
+++ b/content/posts/blog/membership-application-period-for-q4-2013-has-begun.md
@@ -3,6 +3,7 @@ title: Membership Application Period for Q4 2013 has begun
 date: 2013-12-24 12:36
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 Alex has started the membership application process for Q4 2013.

--- a/content/posts/blog/membership-voting-for-q2-2013-has-started.md
+++ b/content/posts/blog/membership-voting-for-q2-2013-has-started.md
@@ -3,6 +3,7 @@ title: Membership voting for Q2 2013 has started
 date: 2013-08-14 02:26
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 Alex has started the membership voting process for Q2 2013 applications and would love it if all the current members chat with the [memberbot](%20xmpp:memberbot@xmpp.org) and vote on the [2013 Q2 membership applications](http://wiki.xmpp.org/web/Membership_Applications_Q2_2013).

--- a/content/posts/blog/presence-at-fosdem.md
+++ b/content/posts/blog/presence-at-fosdem.md
@@ -3,6 +3,7 @@ title: Presence at FOSDEM
 date: 2007-02-01 09:01
 author: ralphm
 blog_id: blog
+category: FOSDEM
 ---
 
 [FOSDEM](http://www.fosdem.org/ "Free and Open source Software Developers' Europe Meeting"), the Free and Open source Software Developers' Europe Meeting, is an annual two-day conference held in Brussels, Belgium. This year the event will take place on 24 and 25 February. It is a large event with 22 main track talks, 25 lightning talks, 20 booths, and 14 developers' rooms. Developers' rooms are centered around a particular project or interest group and can be used for giving presentations and tutorials, discussion, etc., resulting in an additional 146 slots in 2006. While there is no entrance fee, FOSDEM is funded by the generous donations of its 2000+ visitors and several sponsors.

--- a/content/posts/blog/q1-membership-drive.md
+++ b/content/posts/blog/q1-membership-drive.md
@@ -3,6 +3,7 @@ title: Q1 Membership Drive
 date: 2010-01-25 10:36
 author: willsheward
 blog_id: blog
+category: XSF Organisational
 ---
 
 The [XMPP Standards Foundation](http://xmpp.org/xsf/) is currently accepting applications for new members. This application period will run until the end of January.

--- a/content/posts/blog/q22011-membership-application-period-ending-soon.md
+++ b/content/posts/blog/q22011-membership-application-period-ending-soon.md
@@ -3,6 +3,7 @@ title: Q2/2011 Membership Application Period ending soon!
 date: 2011-05-06 00:58
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 Members who are in the list below have until the 10th of May to do reapply. You should already have a wiki account, so please visit the wiki and create your page.

--- a/content/posts/blog/quarterly-membership-application-period-q22011.md
+++ b/content/posts/blog/quarterly-membership-application-period-q22011.md
@@ -3,6 +3,7 @@ title: Quarterly Membership Application Period Q2/2011
 date: 2011-04-21 09:57
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 The XSF is currently holding its quarterly membership application period Q2/2011

--- a/content/posts/blog/quarterly-membership-application-period-q32011.md
+++ b/content/posts/blog/quarterly-membership-application-period-q32011.md
@@ -3,6 +3,7 @@ title: Quarterly Membership Application Period Q3/2011
 date: 2011-06-27 10:29
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 We are currently holding the quarterly membership application period Q3/2011.

--- a/content/posts/blog/seeking-new-xsf-treasurer.md
+++ b/content/posts/blog/seeking-new-xsf-treasurer.md
@@ -3,6 +3,7 @@ title: Seeking new XSF Treasurer
 date: 2015-07-06 11:05
 author: Simon
 blog_id: blog
+category: XSF Organisational
 ---
 
 Until now, St Peter has been handling the XSF Treasurer role. He's stepping down from the role and the XSF Board is looking for someone new.

--- a/content/posts/blog/serving-on-the-board-or-council.md
+++ b/content/posts/blog/serving-on-the-board-or-council.md
@@ -3,6 +3,7 @@ title: Serving on the Board or Council
 date: 2011-09-13 21:45
 author: stpeter
 blog_id: blog
+category: XSF Organisational
 ---
 
 Each year the members of the XSF choose new people to provide technical leadership on the [XMPP Council](http://xmpp.org/about-xmpp/xsf/xmpp-council/) and business leadership on the [XSF Board of Directors](http://xmpp.org/about-xmpp/xsf/the-xsf-board-of-directors/). These roles typically require only a few hours a week over the one-year term, and are a great way to get involved in the XMPP community.

--- a/content/posts/blog/summer-by-the-xml-stream.md
+++ b/content/posts/blog/summer-by-the-xml-stream.md
@@ -3,6 +3,7 @@ title: Summer by the (XML) Stream
 date: 2007-03-20 19:19
 author: stpeter
 blog_id: blog
+category: Google Summer of Code
 ---
 
 The [XMPP Standards Foundation](http://www.xmpp.org/) will once again be [participating](http://code.google.com/soc/xmpp/about.html) in the [Google Summer of Code](http://code.google.com/soc/) for 2007. What is a standards organization doing in the Summer of Code? Well, the Extensible Messaging and Presence Protocol (XMPP) emerged from the Jabber open-source community and we still have many active open-source projects. Plus as [previously mentioned](http://blog.xmpp.org/?p=12) our community is a cohesive blend of open standards, commercial organizations, and open-source developers.

--- a/content/posts/blog/summer-of-code-projects.md
+++ b/content/posts/blog/summer-of-code-projects.md
@@ -3,6 +3,7 @@ title: Summer of Code Projects
 date: 2007-04-12 09:33
 author: stpeter
 blog_id: blog
+category: Google Summer of Code
 ---
 
 Google has announced the 2007 [Summer of Code](http://code.google.com/soc/) projects, and the [XSF projects](http://code.google.com/soc/xmpp/about.html) are as follows:

--- a/content/posts/blog/summer-of-code-success.md
+++ b/content/posts/blog/summer-of-code-success.md
@@ -3,6 +3,7 @@ title: Summer of Code Success
 date: 2007-10-02 15:40
 author: stpeter
 blog_id: blog
+category: Google Summer of Code
 ---
 
 Although the [Google Summer of Code](http://blog.xmpp.org/?p=20) ended weeks ago, we neglected to post a final summary. 

--- a/content/posts/blog/summit-17-the-presentations.md
+++ b/content/posts/blog/summit-17-the-presentations.md
@@ -3,6 +3,7 @@ title: Summit 17 - the presentations
 date: 2015-03-20 05:23
 author: laura
 blog_id: blog
+category: XMPP Summit
 ---
 
 A slightly tardy share, but we have the presentations from Summit 17 in Brussels starting to trickle in! As more come in, this post will get longer (and hopefully have a more permanent home on the new site) but here we go:

--- a/content/posts/blog/the-fosdem-schedule-is-set.md
+++ b/content/posts/blog/the-fosdem-schedule-is-set.md
@@ -3,6 +3,7 @@ title: The FOSDEM Schedule Is Set
 date: 2013-01-22 18:08
 author: stpeter
 blog_id: blog
+category: FOSDEM
 ---
 
 The schedule for the Jabber/XMPP devroom at FOSDEM 2013 is now final. Visit https://fosdem.org/2013/schedule/track/jabber/ for the details and http://wiki.xmpp.org/web/FOSDEM\_2013 for more information about our involvement with FOSDEM 2013.

--- a/content/posts/blog/the-xmpp-fosdem-booth.md
+++ b/content/posts/blog/the-xmpp-fosdem-booth.md
@@ -3,6 +3,7 @@ title: The XMPP FOSDEM Booth
 date: 2009-02-08 06:07
 author: willsheward
 blog_id: blog
+category: FOSDEM
 ---
 
 [caption id="attachment\_256" align="aligncenter" width="422" caption="The team hard at work selling t-shirts!"]![The team hard @ work selling t-shirts!](http://stage.xmpp.org/wp-content/uploads/2009/02/6.jpg "The team hard @ work selling t-shirts!")[/caption]

--- a/content/posts/blog/the-xmpp-summit-10-is-coming.md
+++ b/content/posts/blog/the-xmpp-summit-10-is-coming.md
@@ -3,6 +3,7 @@ title: The XMPP Summit 10 is coming!
 date: 2010-12-10 07:08
 author: florian
 blog_id: blog
+category: XMPP Summit
 ---
 
 Hey, the 10th XMPP Summit is coming up quickly, so we're preparing the participant lists so that we know for how many people we need to book venues etc.

--- a/content/posts/blog/voting-for-the-2013-xsf-board-and-council-has-begun.md
+++ b/content/posts/blog/voting-for-the-2013-xsf-board-and-council-has-begun.md
@@ -3,6 +3,7 @@ title: Voting for the 2013 XSF Board and Council has begun
 date: 2013-10-14 19:01
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 Our most amazing XSF Secretary, Alexander Gnauck, has started the proxy voting process for this years Board and Council.

--- a/content/posts/blog/xmpp-101-fosdem-2009.md
+++ b/content/posts/blog/xmpp-101-fosdem-2009.md
@@ -3,6 +3,7 @@ title: XMPP 101 @ FOSDEM 2009
 date: 2009-03-05 12:37
 author: willsheward
 blog_id: blog
+category: FOSDEM
 ---
 
 This is a (almost) cross-post from Remko Tronçon’s blog at [http://el-tramo.be/](http://el-tramo.be/)

--- a/content/posts/blog/xmpp-at-the-end-of-the-google-summer-of-code-2015.md
+++ b/content/posts/blog/xmpp-at-the-end-of-the-google-summer-of-code-2015.md
@@ -3,6 +3,7 @@ title: XMPP at the end of the Google Summer of Code 2015
 date: 2015-12-18 13:41
 author: Kev
 blog_id: blog
+category: Google Summer of Code
 ---
 
 This year we had six students working on disparate projects for GSoC, and we're delighted that all of them were successful! Here we link to a wrapup blog post from each of the students, and a description of their work from their mentors.

--- a/content/posts/blog/xmpp-in-google-summer-of-code-2015.md
+++ b/content/posts/blog/xmpp-in-google-summer-of-code-2015.md
@@ -3,6 +3,7 @@ title: XMPP in Google Summer of Code 2015
 date: 2015-03-03 06:20
 author: kev
 blog_id: blog
+category: Google Summer of Code
 ---
 
 We've just had the great news that Google have again accepted the XSF to mentor XMPP-related projects in the Google Summer of Code this year. GSoC is a programme whereby Google pays students a stipend to work on open source projects for the summer, and when we're able to participate in this it's a highlight of the year for us. If you are, or know any, talented students with an interest in realtime communication systems we've got a selection of interesting projects at [http://wiki.xmpp.org/web/Summer\_of\_Code\_2015](http://wiki.xmpp.org/web/Summer_of_Code_2015).

--- a/content/posts/blog/xmpp-roundup-10.md
+++ b/content/posts/blog/xmpp-roundup-10.md
@@ -3,6 +3,7 @@ title: XMPP Roundup 10
 date: 2009-06-11 14:13
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 [Reporters: Nicolas Vérité and Peter Saint-Andre]

--- a/content/posts/blog/xmpp-roundup-11.md
+++ b/content/posts/blog/xmpp-roundup-11.md
@@ -3,6 +3,7 @@ title: XMPP Roundup 11
 date: 2009-07-29 11:16
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 [Reporters: Nicolas Vérité and Peter Saint-Andre]

--- a/content/posts/blog/xmpp-roundup-12.md
+++ b/content/posts/blog/xmpp-roundup-12.md
@@ -3,6 +3,7 @@ title: XMPP Roundup 12
 date: 2009-09-16 10:04
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 [Reporter: Nicolas Vérité, assisted by Peter Saint-Andre]

--- a/content/posts/blog/xmpp-roundup-13-articles-talks-and-events.md
+++ b/content/posts/blog/xmpp-roundup-13-articles-talks-and-events.md
@@ -3,6 +3,7 @@ title: XMPP Roundup 13: Articles, talks and events
 date: 2010-01-04 16:05
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 As the XMPP Roundup posts are growing longer each time we send one out, we've decided to split them into smaller posts, each covering a different aspect of XMPP news:

--- a/content/posts/blog/xmpp-roundup-13-new-and-updated-software.md
+++ b/content/posts/blog/xmpp-roundup-13-new-and-updated-software.md
@@ -3,6 +3,7 @@ title: XMPP Roundup 13: new and updated software
 date: 2010-01-29 08:35
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 Welcome to the XMPP software Roundup 13. As announced in the [latest Roundup](http://blog.xmpp.org/index.php/2010/01/xmpp-roundup-13-articles-talks-and-events/), we have split it into different parts. The first part covered articles, talks and events. This post covers new and updated software, the next one will cover XMPP services.

--- a/content/posts/blog/xmpp-roundup-13-services.md
+++ b/content/posts/blog/xmpp-roundup-13-services.md
@@ -3,6 +3,7 @@ title: XMPP Roundup 13: services
 date: 2010-02-05 08:11
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 Live from the XMPP Hackfest in Brussels, Belgium, here is the XMPP Roundup 13, dedicated this time to new and updated services. As announced before, the XMPP Roundup has been split into separate parts with "articles, talks and events" and "new and updated software" already published.

--- a/content/posts/blog/xmpp-roundup-13-specifications.md
+++ b/content/posts/blog/xmpp-roundup-13-specifications.md
@@ -3,6 +3,7 @@ title: XMPP Roundup 13: Specifications
 date: 2010-02-22 11:50
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 Welcome to the Specification part of the XMPP Roundup \#13, your irregular news from the XMPP community. It has been a long time since we have reported on specifications changes. Here is a short summary of what happened since September.

--- a/content/posts/blog/xmpp-roundup-3.md
+++ b/content/posts/blog/xmpp-roundup-3.md
@@ -3,6 +3,7 @@ title: XMPP Roundup #4
 date: 2008-12-02 14:52
 author: willsheward
 blog_id: blog
+category: XMPP Roundup
 ---
 
 **Is There a New Successor to SIP?**

--- a/content/posts/blog/xmpp-roundup-4-new-year-edition.md
+++ b/content/posts/blog/xmpp-roundup-4-new-year-edition.md
@@ -3,6 +3,7 @@ title: XMPP Roundup #5 "New Year edition"
 date: 2009-01-04 03:57
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 Welcome to the fifth [roundup](http://blog.xmpp.org/?cat=12) of XMPP activity worldwide. This report is authored by [Nicolas Vérité](http://nyco.wordpress.com/), [Laurent Lathieyre](http://ubikod.com/otmf/) and [Jack Moffitt](http://metajack.im/). This is a very long article since we had a lot of activity these weeks.

--- a/content/posts/blog/xmpp-roundup-5.md
+++ b/content/posts/blog/xmpp-roundup-5.md
@@ -3,6 +3,7 @@ title: XMPP Roundup #6
 date: 2009-02-16 10:07
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 **Foreword**

--- a/content/posts/blog/xmpp-roundup-7-brussels-report.md
+++ b/content/posts/blog/xmpp-roundup-7-brussels-report.md
@@ -3,6 +3,7 @@ title: XMPP Roundup #7: Brussels Report
 date: 2009-02-25 21:44
 author: stpeter
 blog_id: blog
+category: XMPP Roundup
 ---
 
 [Reporter: Peter Saint-Andre]

--- a/content/posts/blog/xmpp-roundup-8.md
+++ b/content/posts/blog/xmpp-roundup-8.md
@@ -3,6 +3,7 @@ title: XMPP Roundup #8
 date: 2009-04-21 04:43
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 [Reporters: Nicolas Vérité and Peter Saint-Andre]

--- a/content/posts/blog/xmpp-roundup-9.md
+++ b/content/posts/blog/xmpp-roundup-9.md
@@ -3,6 +3,7 @@ title: XMPP Roundup #9
 date: 2009-05-11 13:20
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 [Reporters: Nicolas Vérité and Peter Saint-Andre]

--- a/content/posts/blog/xmpp-roundup-on-new-and-updated-software.md
+++ b/content/posts/blog/xmpp-roundup-on-new-and-updated-software.md
@@ -3,6 +3,7 @@ title: XMPP Roundup on new and updated software
 date: 2010-04-23 08:37
 author: Nyco
 blog_id: blog
+category: XMPP Roundup
 ---
 
 Welcome to the 14th Roundup of the XMPP community, part dedicated to new and updated software.

--- a/content/posts/blog/xmpp-roundup.md
+++ b/content/posts/blog/xmpp-roundup.md
@@ -3,6 +3,7 @@ title: XMPP Roundup #2
 date: 2008-11-10 15:19
 author: willsheward
 blog_id: blog
+category: XMPP Roundup
 ---
 
 This is the second in what we hope will be a regular (perhaps even weekly) roundup of blog posts, announcements, and news stories relating to and featuring XMPP.

--- a/content/posts/blog/xmpp-summit-1.md
+++ b/content/posts/blog/xmpp-summit-1.md
@@ -3,6 +3,7 @@ title: XMPP Summit 1
 date: 2010-08-10 04:46
 author: admin
 blog_id: blog
+category: XMPP Summit
 ---
 
 The first developer conference held by the XMPP Standards Foundation occurred on July 24 and 25, 2006, in Portland, Oregon, USA (the same week as [OSCON 2006](http://conferences.oreillynet.com/os2006/)).

--- a/content/posts/blog/xmpp-summit-10-at-fosdem-2011-update.md
+++ b/content/posts/blog/xmpp-summit-10-at-fosdem-2011-update.md
@@ -3,6 +3,7 @@ title: XMPP Summit 10 at FOSDEM 2011 - update
 date: 2011-01-20 11:12
 author: bear
 blog_id: blog
+category: XMPP Summit
 ---
 
 In a bit more than two weeks (!) the tenth [XMPP Summit](http://xmpp.org/participate/the-xmpp-summit/) to be held by the XMPP Standards Foundation will happen. February 4-7, 2011, in Brussels, Belgium (the same weekend as [FOSDEM 2011](http://www.fosdem.org/)).

--- a/content/posts/blog/xmpp-summit-10.md
+++ b/content/posts/blog/xmpp-summit-10.md
@@ -3,6 +3,7 @@ title: XMPP Summit 10
 date: 2010-12-07 09:53
 author: florian
 blog_id: blog
+category: XMPP Summit
 ---
 
 The tenth [XMPP Summit](/participate/the-xmpp-summit/) held by the XMPP Standards Foundation happened on February 4-7, 2011, in Brussels, Belgium (the same weekend as [FOSDEM 2011](http://www.fosdem.org/)).

--- a/content/posts/blog/xmpp-summit-11.md
+++ b/content/posts/blog/xmpp-summit-11.md
@@ -3,6 +3,7 @@ title: XMPP Summit 11
 date: 2012-01-10 08:49
 author: florian
 blog_id: blog
+category: XMPP Summit
 ---
 
 The 11th XMPP Summit will be held on February 3-6, 2011, in Brussels, Belgium (the same weekend as [FOSDEM 2012](http://fosdem.org/2012/ "FOSDEM 2012")).

--- a/content/posts/blog/xmpp-summit-12.md
+++ b/content/posts/blog/xmpp-summit-12.md
@@ -3,6 +3,7 @@ title: XMPP Summit 12
 date: 2013-07-30 12:33
 author: joachim.lindborg
 blog_id: blog
+category: XMPP Summit
 ---
 
 We are using a [wiki page](http://wiki.xmpp.org/web/Summit_12) for coordination, please go there!

--- a/content/posts/blog/xmpp-summit-13-in-brussels.md
+++ b/content/posts/blog/xmpp-summit-13-in-brussels.md
@@ -3,6 +3,7 @@ title: XMPP Summit 13 in Brussels
 date: 2012-12-17 12:06
 author: stpeter
 blog_id: blog
+category: XMPP Summit
 ---
 
 This is just a quick note to inform you that the XSF will hold its 13th XMPP Summit in Brussels, Belgium on January 31 and February 1, 2013. This is Thursday and Friday before FOSDEM 2013. Details are on the wiki at http://wiki.xmpp.org/web/Summit\_13 and join the summit@xmpp.org list to discuss.

--- a/content/posts/blog/xmpp-summit-13-is-complete.md
+++ b/content/posts/blog/xmpp-summit-13-is-complete.md
@@ -3,6 +3,7 @@ title: XMPP Summit 13 is complete
 date: 2013-03-07 12:57
 author: bear
 blog_id: blog
+category: XMPP Summit
 ---
 
 The [XSF](http://xmpp.org "XSF") recently held the [XMPP Summit 13](http://wiki.xmpp.org/web/Summit_13 "XMPP Summit 13") in Brussels this past week, specifically January 31 and February 1, 2013 -- and truth be told we are all exhausted and amazed at how much discussion and planning can happen in two days when you get a bunch of bright, smart folks in the same room.

--- a/content/posts/blog/xmpp-summit-13.md
+++ b/content/posts/blog/xmpp-summit-13.md
@@ -3,6 +3,7 @@ title: XMPP Summit 13
 date: 2013-07-30 12:52
 author: joachim.lindborg
 blog_id: blog
+category: XMPP Summit
 ---
 
 XSF held its 13th XMPP Summit in Brussels, Belgium on January 31 and February 1, 2013. The Thursday and Friday before FOSDEM 2013.

--- a/content/posts/blog/xmpp-summit-15.md
+++ b/content/posts/blog/xmpp-summit-15.md
@@ -3,6 +3,7 @@ title: XMPP Summit 15
 date: 2014-01-10 04:23
 author: bear
 blog_id: blog
+category: XMPP Summit
 ---
 
 The 15th Summit is fast approaching!

--- a/content/posts/blog/xmpp-summit-17.md
+++ b/content/posts/blog/xmpp-summit-17.md
@@ -3,6 +3,7 @@ title: XMPP Summit 17
 date: 2015-01-08 04:25
 author: joachim.lindborg
 blog_id: blog
+category: XMPP Summit
 ---
 
 The 17th XSF Summit is approaching!

--- a/content/posts/blog/xmpp-summit-2.md
+++ b/content/posts/blog/xmpp-summit-2.md
@@ -3,6 +3,7 @@ title: XMPP Summit 2
 date: 2010-08-10 04:41
 author: admin
 blog_id: blog
+category: XMPP Summit
 ---
 
 The second developer conference held by the XMPP Standards Foundation occurred on February 26, 2007, in Brussels, Belgium (the same week as [FOSDEM 2007](http://www.fosdem.org/)).

--- a/content/posts/blog/xmpp-summit-21.md
+++ b/content/posts/blog/xmpp-summit-21.md
@@ -3,6 +3,7 @@ title: XMPP Summit 21
 date: 2017-02-27 18:50
 author: Guus
 blog_id: blog
+category: XMPP Summit
 ---
 
 This year, the [XMPP Standards Foundation](https://xmpp.org/) again gathered in force to attend the summit, that traditionally precedes the [FOSDEM event](https://fosdem.org/2017/) in Brussels, Belgium. Barely fitting in the (rather sizable) room that was made available to us by Cisco, the XSF members had a fruitful two-day meeting. 

--- a/content/posts/blog/xmpp-summit-3.md
+++ b/content/posts/blog/xmpp-summit-3.md
@@ -3,6 +3,7 @@ title: XMPP Summit 3
 date: 2010-08-10 04:40
 author: admin
 blog_id: blog
+category: XMPP Summit
 ---
 
 The XMPP Standards Foundation held its third developer conference on July 23 and 24, 2007, in Portland, Oregon, USA (the same week as [OSCON 2007](http://conferences.oreillynet.com/os2007/)).

--- a/content/posts/blog/xmpp-summit-4.md
+++ b/content/posts/blog/xmpp-summit-4.md
@@ -3,6 +3,7 @@ title: XMPP Summit 4
 date: 2010-08-10 04:38
 author: admin
 blog_id: blog
+category: XMPP Summit
 ---
 
 The fourth developer conference held by the XMPP Standards Foundation occurred on February 24 and 25, 2008, in Brussels, Belgium (the same week as [FOSDEM 2008](http://www.fosdem.org/)).

--- a/content/posts/blog/xmpp-summit-5.md
+++ b/content/posts/blog/xmpp-summit-5.md
@@ -3,6 +3,7 @@ title: XMPP Summit 5
 date: 2010-08-10 04:36
 author: admin
 blog_id: blog
+category: XMPP Summit
 ---
 
 The XMPP Standards Foundation will hold its fifth "XMPP Summit" meeting on July 21 and 22, 2008, in Portland, Oregon, USA (the same week as [OSCON 2008](http://conferences.oreilly.com/oscon/)).

--- a/content/posts/blog/xmpp-summit-6.md
+++ b/content/posts/blog/xmpp-summit-6.md
@@ -3,6 +3,7 @@ title: XMPP Summit 6
 date: 2010-08-10 04:33
 author: admin
 blog_id: blog
+category: XMPP Summit
 ---
 
 The sixth [XMPP Summit](/participate/the-xmpp-summit/) to be held by the XMPP Standards Foundation will occur on February 6-9, 2009, in Brussels, Belgium (the same weekend as [FOSDEM 2009](http://www.fosdem.org/)).

--- a/content/posts/blog/xmpp-summit-7.md
+++ b/content/posts/blog/xmpp-summit-7.md
@@ -3,6 +3,7 @@ title: XMPP Summit 7
 date: 2010-08-10 04:32
 author: admin
 blog_id: blog
+category: XMPP Summit
 ---
 
 The XMPP Standards Foundation will hold its seventh "XMPP Summit" meeting on July 20 and 21, 2009, in San Jose, California, USA. Thanks to the generosity of [O'Reilly](http://oreilly.com/), the Summit will be held on the premises of [OSCON 2009](http://en.oreilly.com/oscon2009).

--- a/content/posts/blog/xmpp-summit-8-fosdem-2010.md
+++ b/content/posts/blog/xmpp-summit-8-fosdem-2010.md
@@ -3,6 +3,7 @@ title: XMPP Summit 8 / FOSDEM 2010
 date: 2009-12-23 11:28
 author: willsheward
 blog_id: blog
+category: XMPP Summit
 ---
 
 Once again the XSF will be combining one of our Summit meetings with attendance at [FOSDEM](http://fosdem.org/) in Brussels on the weekend of 6/7 February 2010.

--- a/content/posts/blog/xmpp-summit-8.md
+++ b/content/posts/blog/xmpp-summit-8.md
@@ -3,6 +3,7 @@ title: XMPP Summit 8
 date: 2010-08-10 04:29
 author: admin
 blog_id: blog
+category: XMPP Summit
 ---
 
 The eighth [XMPP Summit](/participate/the-xmpp-summit/) to be held by the XMPP Standards Foundation occured on February 5-8, 2010, in Brussels, Belgium (the same weekend as [FOSDEM 2010](http://www.fosdem.org/)).

--- a/content/posts/blog/xmpp-summit-9-preview.md
+++ b/content/posts/blog/xmpp-summit-9-preview.md
@@ -3,6 +3,7 @@ title: XMPP Summit #9 - Preview
 date: 2010-07-20 16:25
 author: bear
 blog_id: blog
+category: XMPP Summit
 ---
 
 (**editor's note**: apologies for this appearing now, it got stuck in the publish queue and I did not notice it until I went to publish the Day One Summary that follows. d'oh!)

--- a/content/posts/blog/xmpp-summit-9.md
+++ b/content/posts/blog/xmpp-summit-9.md
@@ -3,6 +3,7 @@ title: XMPP Summit 9
 date: 2010-12-01 10:57
 author: willsheward
 blog_id: blog
+category: XMPP Summit
 ---
 
 The ninth [XMPP Summit](/participate/the-xmpp-summit/) to be held by the XMPP Standards Foundation was held at [OSCON 2010](http://www.oscon.com/oscon2010) in Portland, Oregon (USA) on Monday July 19 and Tuesday July 20, 2010.

--- a/content/posts/blog/xmpp-summit-coming-soon-to-a-fosdem-near-you.md
+++ b/content/posts/blog/xmpp-summit-coming-soon-to-a-fosdem-near-you.md
@@ -3,6 +3,7 @@ title: XMPP Summit coming soon to a FOSDEM near you!
 date: 2012-01-06 17:27
 author: dwd
 blog_id: blog
+category: XMPP Summit
 ---
 
 As you'll be aware if you've been following the XSF's mailing lists and chatrooms, [FOSDEM 2012](http://fosdem.org/2012/ "FOSDEM 2012") is coming, and that means it's also time for the [XMPP Summit 11](http://wiki.xmpp.org/web/Summit_11 "XMPP Summit 11").

--- a/content/posts/blog/xmpp-summit-day-one-summary.md
+++ b/content/posts/blog/xmpp-summit-day-one-summary.md
@@ -3,6 +3,7 @@ title: XMPP Summit - Day One Summary
 date: 2010-07-20 16:31
 author: bear
 blog_id: blog
+category: XMPP Summit
 ---
 
 We started with Bear and Joe giving a brief welcome and then we went around the room and allowed the attendees to introduce themselves. After the introductions we worked out the Agenda using the barcamp style of posting topics to the white-board and haggling over which order to work thru them.

--- a/content/posts/blog/xmpp-summit-jingle-thingle.md
+++ b/content/posts/blog/xmpp-summit-jingle-thingle.md
@@ -3,6 +3,7 @@ title: XMPP Summit - Jingle Thingle
 date: 2009-02-06 05:33
 author: willsheward
 blog_id: blog
+category: XMPP Summit
 ---
 
 Underway...

--- a/content/posts/blog/xmpp-summit-update.md
+++ b/content/posts/blog/xmpp-summit-update.md
@@ -3,6 +3,7 @@ title: XMPP Summit 10 update
 date: 2011-01-29 16:31
 author: bear
 blog_id: blog
+category: XMPP Summit
 ---
 
 Six days (!) until the tenth [XMPP Summit](http://xmpp.org/participate/the-xmpp-summit/) to be held by the XMPP Standards Foundation will happen.

--- a/content/posts/blog/xmpp-summit.md
+++ b/content/posts/blog/xmpp-summit.md
@@ -3,6 +3,7 @@ title: XMPP Summit
 date: 2012-06-15 12:05
 author: stpeter
 blog_id: blog
+category: XMPP Summit
 ---
 
 We've decided to hold the next XMPP Summit in Portland, Oregon at the end of October. Mark your calendars for October 25th, which is the day after the [Keeping it Realtime conference](http://2012.krtconf.com/). Co-locating the XMPP Summit with krtconf makes a lot of sense, since both events are focused on building real-time applications.

--- a/content/posts/blog/xsf-board-meeting-for-2010-11-24.md
+++ b/content/posts/blog/xsf-board-meeting-for-2010-11-24.md
@@ -3,6 +3,7 @@ title: XSF Board Meeting for 2010-11-24
 date: 2010-11-24 12:49
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 The minutes for the most recent XSF Board Meeting on 2010-11-24 can be found as a post to the XSF Members mailing list.  You can view the [chat log](http://xmpp.org:5290/muc_log/muc.xmpp.org/xsf/101124/) or read the [summary post](http://mail.jabber.org/pipermail/members/2010-November/006085.html).

--- a/content/posts/blog/xsf-gsoc-students-2015.md
+++ b/content/posts/blog/xsf-gsoc-students-2015.md
@@ -3,6 +3,7 @@ title: XSF GSoC Students 2015
 date: 2015-04-28 09:43
 author: kev
 blog_id: blog
+category: Google Summer of Code
 ---
 
 This year, we've been lucky enough to have had many great applications to take part in Google Summer of Code under the XSF. We've selected the following six students/projects and are looking forward to working with them over an exciting summer:

--- a/content/posts/blog/xsf-membership-application-period-for-q4-is-open.md
+++ b/content/posts/blog/xsf-membership-application-period-for-q4-is-open.md
@@ -3,6 +3,7 @@ title: XSF Membership Application Period for Q4 is open
 date: 2010-11-08 14:08
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 The XMPP Standards Foundation is currently accepting applications for new members.

--- a/content/posts/blog/xsf-membership-vote-update.md
+++ b/content/posts/blog/xsf-membership-vote-update.md
@@ -3,6 +3,7 @@ title: XSF Membership Vote Update
 date: 2010-12-08 06:16
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 We still need folks who haven't voted to do so as Alexander has reported that our current voting tally does not fulfill the required quorum.

--- a/content/posts/blog/xsf-membership-voting-has-started.md
+++ b/content/posts/blog/xsf-membership-voting-has-started.md
@@ -3,6 +3,7 @@ title: XSF Membership Voting has started
 date: 2010-11-30 11:22
 author: bear
 blog_id: blog
+category: XSF Organisational
 ---
 
 Part of the membership process for the XSF is that new and renewing members post to our wiki their "application" and current members vote to approve the application - this proxy voting has now started and will continue until the close of business on December 14th. On December 15th we will have one of the few required "all hands" meetings to formally approve the voting results.

--- a/content/posts/blog/xsf-membership.md
+++ b/content/posts/blog/xsf-membership.md
@@ -3,6 +3,7 @@ title: XSF Membership
 date: 2007-07-02 13:52
 author: stpeter
 blog_id: blog
+category: XSF Organisational
 ---
 
 Over the weekend, [Alexander Gnauck](http://www.xmpp.org/xsf/people/agnauck.shtml) ([Secretary](http://www.xmpp.org/xsf/secretary.shtml) of the XSF) posted a [notice](http://mail.jabber.org/pipermail/jdev/2007-July/025504.html) about the Q3 membership application period. So this seems like a good occasion to explain a bit about how the [XMPP Standards Foundation](http://www.xmpp.org/) works.

--- a/content/posts/blog/xsf-welcomes-google-summer-of-code-2011-students.md
+++ b/content/posts/blog/xsf-welcomes-google-summer-of-code-2011-students.md
@@ -3,6 +3,7 @@ title: XSF Welcomes Google Summer of Code 2011 Students
 date: 2011-04-26 04:40
 author: bear
 blog_id: blog
+category: Google Summer of Code
 ---
 
 With the selection process over, we now know that the [XSF](http://xmpp.org) will be working with five students for the [2011 Google Summer of Code](http://www.google-melange.com/gsoc/org/google/gsoc2011/xsf)!


### PR DESCRIPTION
Currently, all blog posts are in the same default category 'misc'. This PR adds some other categories.

Certain posts could go into two categories, but I've yet to figure out how that's done. Comma-separated won't work, nor will adding the header twice. 

Feel free to improve or add to this.