### PR TITLE
Fixes rendering of XEPs that use a wrong css reference.

### DIFF
--- a/content/xmpp.css
+++ b/content/xmpp.css
@@ -1,0 +1,158 @@
+BODY {
+    background-color: #ffffff;
+    color: #000000;
+    font-family: Verdana, Arial, Helvetica, Geneva, sans-serif;
+    font-size: small;
+    line-height: 130%;
+    margin-left: 7%;
+    margin-right: 7%;
+    }
+#left {
+    border: 0px;
+    border-color: #aaaaaa;
+    border-right: 1px;
+    border-style: solid;
+    float: left;
+    margin: 0% 0% 5% 0%;
+    padding: 4px 2% 10px 2%;
+    width: 12%;
+    }
+#main {
+    border: 0px;
+    color: #000000;
+    font-weight: normal; 
+    margin: 0% 0% 5% 17%;
+    padding: 4px 2% 10px 2%;
+    text-decoration: none;
+    }
+#foot {
+    border-top: 0px solid;
+    clear: both;
+    color: #666666;
+    font-size: x-small;
+    font-weight: normal; 
+    text-align: center;
+    text-decoration: none;
+    }
+A:link {
+    color: #336699;
+    }
+A.standardsButton {
+    background-color: #ff6600;
+    border: 1px solid;
+    border-color: #ffc8a4 #7d3302 #3f1a01 #ff9a57;
+    color: #ffffff;
+    padding: 0px 3px 0px 3px;
+    text-decoration: none;
+    margin: 0px;
+    }
+A:visited {
+    color: #663399;
+    }
+H1, H2, H3, H4, H5, H6 {
+    color: #336699;
+    line-height: 0.8;
+    }
+pre {
+    font-family: Courier, monospace;
+    background-color: #e0e9f2;
+    padding: 0.4em;
+    border: 1px solid #369;
+    }
+ul {
+    list-style: disc outside;
+    }
+.body {
+    font-family: Verdana, Arial, Helvetica, Geneva, sans-serif;
+    font-size: small;
+    }
+.bold {
+    font-weight: bold;
+    }
+.box {
+    border: thin dotted; 
+    padding-bottom: 1em; 
+    padding-left: 2em; 
+    padding-right: 2em; 
+    padding-top: 1em; 
+    }
+.caption {
+    font-weight: bold;
+    }
+.code {
+    font-family: "Courier New", Courier, monospace;
+    white-space: pre;
+    }
+.def {
+    text-indent: -6.3em; 
+    padding-bottom: 1em; 
+    padding-left: 6.5em; 
+    padding-right: 10em; 
+    padding-top: 1em; 
+    }
+.em {
+    font-style: italic;
+    }
+.example {
+    background-color: #f2ee6e;
+    margin: 0.4em 5%;
+    border: 1px solid #999633;
+    padding: 0 0.4em;
+    }
+.indent {
+    padding-left: 5%;
+    padding-right: 5%;
+    }
+.head {
+    color: #336699;
+    font-weight: bold;
+    }
+.highlight {
+    color: #336699;
+    }
+.nav { 
+    font-size: small;
+    line-height: 45%;
+    text-decoration: none; 
+    white-space: nowrap; 
+    } 
+.navhead { 
+    color: #336699;
+    font-size: medium;
+    line-height: 90%;
+    padding-left: 0px;
+    text-decoration: none; 
+    }
+.pagehead {
+    color: #336699;
+    text-decoration: none; 
+    }
+A:visited.pagehead {
+    color: #336699;
+    text-decoration: none; 
+    }
+.ref {
+    font-weight: bold;
+    }
+.strong {
+    font-weight: bold;
+    }
+.subhead {
+    font-style: italic;
+    }
+.sub {
+    font-size: xx-small;
+    vertical-align: sub;
+    }
+.super {
+    font-size: xx-small;
+    vertical-align: super;
+    }
+.tablebody {
+    font-family: Verdana, Arial, Helvetica, Geneva, sans-serif;
+    font-size: small;
+    white-space: nowrap;
+    }
+.event {
+	color: #336699;
+}


### PR DESCRIPTION
This is a copy of /extensions/xmpp.css, that fixes issue #202. At some point, all XEPs will either have their own inline version of the CSS, reference the original file, another solution is found (replace this file with a redirect?) At that time, this file can be removed.