### PR TITLE
Fixed typo in blogpost date.

### DIFF
--- a/content/posts/blog/xmpp-summit-21.md
+++ b/content/posts/blog/xmpp-summit-21.md
@@ -1,6 +1,6 @@
 ---
 title: XMPP Summit 21
-date: 2017-02-27 18:50
+date: 2017-01-27 18:50
 author: Guus
 blog_id: blog
 ---


### PR DESCRIPTION
As pointed out by @ralphm, I made a typo, causing the blogpost to be written in the future.