### PR TITLE
Fix pull request links for new data-driven software lists.

### DIFF
--- a/content/pages/software/clients.md
+++ b/content/pages/software/clients.md
@@ -26,4 +26,4 @@ An XMPP client is any software or application that enables you to connect to an 
 
 > Note: The following software was not developed by the XMPP Standards Foundation and has not been formally tested for standards compliance, usability, reliability, or performance.
 
-__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If you spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/edit/master/content/pages/software/clients.md)
+__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If you spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/edit/master/data/clients.json)

--- a/content/pages/software/libraries.md
+++ b/content/pages/software/libraries.md
@@ -26,4 +26,4 @@ Code libraries are available for many different programming languages, thus enab
 
 > Note: The following software was not developed by the XMPP Standards Foundation and has not been formally tested for standards compliance, usability, reliability, or performance.
 
-__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If you spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org)
+__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If you spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/edit/master/data/libraries.json)

--- a/content/pages/software/servers.md
+++ b/content/pages/software/servers.md
@@ -25,4 +25,4 @@ An XMPP server provides basic messaging, presence, and XML routing features. Thi
 
 > Note: The following software was not developed by the XMPP Standards Foundation and has not been formally tested for standards compliance, usability, reliability, or performance.
 
-__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If you spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org)
+__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If you spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/edit/master/data/servers.json)


### PR DESCRIPTION
Lists added in d8cec85 .. e6c19ce, but these links were forgotten.

This actually changes the servers and libraries links to be a direct
edit link, the way clients was. I think that's better.