### PR TITLE
Several updates to the software registry tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,14 @@ language: python
 cache: apt
 notifications:
   email: false
+python:
+  - 2.7
+  - 3.3
 install:
-- pip install pelican==3.3 ghp-import markdown
+- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install pelican==3.3 ghp-import markdown; fi
 script:
-  - export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/dist-packages
-  - make html
+- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/dist-packages; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then make html; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then ./data/lint-list.py clients.json; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then ./data/lint-list.py servers.json; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then ./data/lint-list.py libraries.json; fi

--- a/content/pages/software/libraries.md
+++ b/content/pages/software/libraries.md
@@ -19,7 +19,7 @@ Sidebar_menu_elem_url_3: software/libraries
 Content_layout: multiple-columns
 Template: software_list
 Swlist_Source: libraries
-Swlist_Info_Column_Head: Languages
+Swlist_Platforms_Column_Head: Languages
 ---
 
 Code libraries are available for many different programming languages, thus enabling developers to build a wide variety of XMPP-enabled applications.

--- a/data/README.rst
+++ b/data/README.rst
@@ -9,7 +9,7 @@ The listing is split in three categories:
 * **Clients** are found in the ``clients.json``, and
 * **Libraries** are found in the ``libraries.json``.
 
-The tooling is the same for all three categories. What differs is what ``info`` means. For clients and servers, this is the list of platforms a project runs on. For libraries, this is the list of languages they support.
+The tooling is the same for all three categories. What differs is what ``platforms`` means. For clients and servers, this is the list of platforms a project runs on. For libraries, this is the list of languages they support.
 
 **Note:** You can of course also manually edit the JSON files if that’s what you prefer. Make sure to keep the diff minimal. All times are UTC.
 
@@ -19,32 +19,26 @@ Renewing your existing entry
 
 For renewing (and changing) an existing entry, you can use the ``update-entry.py`` tool from the command line. Example::
 
-  ./update-entry clients.json Conversations
+  ./update-entry.py clients.json Conversations
 
 The tool will ask for confirmation::
 
-  old entry:
-  {
-      "info": [
-          "Mobile (Android)"
-      ],
-      "last_renewed": null,
-      "name": "Conversations",
-      "url": "https://github.com/siacs/Conversations"
-  }
-
-  new entry:
-  {
-      "info": [
-          "Mobile (Android)"
-      ],
-      "last_renewed": "2017-03-16T07:24:41",
-      "name": "Conversations",
-      "url": "https://github.com/siacs/Conversations"
-  }
+  difference between old and new:
+  --- before
+  +++ after
+  @@ -1,8 +1,8 @@
+   {
+  -    "last_renewed": null,
+  +    "last_renewed": "2017-03-23T15:13:58",
+       "name": "Conversations",
+       "platforms": [
+           "Android"
+       ],
+       "url": "https://github.com/siacs/Conversations"
+   }
   is this okay? [y/n]
 
-After confirmation, it writes the changes to the ``clients.json``. This works just the same for ``servers.json`` and ``libraries.json``. You can then add and commit the changes to git as usual. Make a PR on GitHub.
+After confirmation, it writes the changes to the ``clients.json``. This works just the same for ``servers.json`` and ``libraries.json``. You can then add and commit the changes to git as usual. **Validate** that your entry is correct using the ``./lint-tool.py`` on the respective JSON file and then make a Pull Request on GitHub.
 
 
 Updating information
@@ -53,7 +47,8 @@ Updating information
 When asking the tool for ``--help``, you will notice that it supports a few other options too::
 
   usage: update-entry.py [-h] [--rename NAME] [--set-url URL]
-                         [--set-info INFO [INFO ...]] [--no-renewal] [--no-ask]
+                         [--set-platforms PLATFORM [PLATFORM ...]]
+                         [--no-renewal] [--no-ask]
                          JSONFILE [NAME]
 
   Renew a software entry in the software list.
@@ -66,7 +61,7 @@ When asking the tool for ``--help``, you will notice that it supports a few othe
     -h, --help            show this help message and exit
     --rename NAME         Rename the project
     --set-url URL         Change the URL of the project
-    --set-info INFO [INFO ...]
+    --set-platforms PLATFORM [PLATFORM ...]
                           Change the contents of the last column
     --no-renewal
     --no-ask              Do not ask for confirmation before applying changes.
@@ -75,24 +70,30 @@ The following options are useful for updating information about your project:
 
 * ``--rename``: If you need to change the name in the registry, this option is for you. It will not allow you to replace another project.
 * ``--set-url``: Change the URL to which your project links.
-* ``--set-info``: Set the words shown in the third column: if your project is a client or server, this is the list of platforms it runs on. if your project is a library, this is the language(s) it supports.
+* ``--set-platforms``: Set the words shown in the third column: if your project is a client or server, this is the list of platforms it runs on. if your project is a library, this is the language(s) it supports.
 
   Example use::
 
-    ./update-entry.py clients.json Pidgin --set-info 'Windows' 'Linux'
+    ./update-entry.py clients.json Pidgin --set-platforms 'Windows' 'Linux'
+
+  **Note:** For clients and servers, the platforms are restricted to those named in the ``platform.json`` file!
 
 Do not set ``--no-ask`` and always be sure to review that your changes do what you intend them to do.
 
 If you do not know how to spell your project correctly, leave out the ``NAME`` argument; the tool will list the project it knows.
 
+Do not forget to **validate** that your entry is correct using the ``./lint-tool.py`` on the respective JSON file and then make a Pull Request on GitHub.
+
 
 Add a new entry
 ===============
 
-There is no tooling for that. Add the following template to the respective ``json`` file::
+There is no tooling for that. Add the following template to the respective ``json`` file:
+
+.. code-block:: json
 
       {
-          "info": ["GNU Hurd", "Plan9"],
+          "platforms": ["GNU Hurd", "Plan9"],
           "last_renewed": null,
           "name": "My Fancy New Client",
           "url": "https://myfancyclient.example"
@@ -104,6 +105,14 @@ Insert it into the top-level JSON Array as last element by adding a comma after 
 Remove an existing entry
 ========================
 
-Simply drop the corresponding JSON Object from the array and make a PR. You may use the ``./update-entry.py`` tool like this to ensure that the syntax is still valid::
+Simply drop the corresponding JSON Object from the array and make a PR. Use the ``./lint-list.py`` tool to ensure that the syntax is still valid.
 
-  ./update-entry.py whichever.json
+
+Validating Entries
+==================
+
+To validate that the list contents are okay, use the ``lint-list.py`` tool::
+
+  ./lint-list.py clients.json
+
+Note: The tool can only be used on the three lists and does not require an absolute path to the list.

--- a/data/clients.json
+++ b/data/clients.json
@@ -1,606 +1,606 @@
 [
     {
-        "info": [
-            "macOS"
-        ],
         "last_renewed": null,
         "name": "Adium",
+        "platforms": [
+            "macOS"
+        ],
         "url": "http://adium.im"
     },
     {
-        "info": [
-            "macOS"
-        ],
         "last_renewed": null,
         "name": "Apple Messages",
+        "platforms": [
+            "macOS"
+        ],
         "url": "http://www.apple.com/ios/messages/"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "AQQ",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://aqq.eu"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "AstraChat",
+        "platforms": [
             "Android",
             "iOS",
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "AstraChat",
         "url": "http://astrachat.com"
     },
     {
-        "info": [
-            "Android"
-        ],
         "last_renewed": null,
         "name": "Beem",
+        "platforms": [
+            "Android"
+        ],
         "url": "http://beem-project.com"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "BitlBee",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://bitlbee.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "BlueJabb",
+        "platforms": [
             "Android",
             "Blackberry",
             "Nokia Symbian"
         ],
-        "last_renewed": null,
-        "name": "BlueJabb",
         "url": "http://bluejabb.com"
     },
     {
-        "info": [
-            "iOS"
-        ],
         "last_renewed": null,
         "name": "Boogie Chat",
+        "platforms": [
+            "iOS"
+        ],
         "url": "https://itunes.apple.com/app/boogie-chat/id779423907?mt=8"
     },
     {
-        "info": [
-            "Mobile (Android)"
-        ],
         "last_renewed": "2017-03-23T14:02:52",
         "name": "Bruno the Jabber Bear",
+        "platforms": [
+            "Mobile (Android)"
+        ],
         "url": "https://yaxim.org/bruno/"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Buddycloud",
+        "platforms": [
             "Mobile",
             "Web",
             "Console"
         ],
-        "last_renewed": null,
-        "name": "Buddycloud",
         "url": "http://buddycloud.com"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "Candy",
+        "platforms": [
+            "Browser"
+        ],
         "url": "https://candy-chat.github.io/candy/"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "ChatSecure",
+        "platforms": [
             "Android",
             "iOS"
         ],
-        "last_renewed": null,
-        "name": "ChatSecure",
         "url": "https://chatsecure.org/"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Coccinella",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Coccinella",
         "url": "http://coccinella.im"
     },
     {
-        "info": [
-            "Android"
-        ],
         "last_renewed": null,
         "name": "Conversations",
+        "platforms": [
+            "Android"
+        ],
         "url": "https://github.com/siacs/Conversations"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "Converse.js",
+        "platforms": [
+            "Browser"
+        ],
         "url": "http://conversejs.org"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "Coversant SoapBox Communicator",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://coversant.com"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "eM Client",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://emclient.com"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "Empathy",
+        "platforms": [
+            "Linux"
+        ],
         "url": "https://wiki.gnome.org/Apps/Empathy"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "Finch",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://developer.pidgin.im"
     },
     {
-        "info": [
+        "last_renewed": "2017-03-23T17:00:00",
+        "name": "Gajim",
+        "platforms": [
             "Linux",
             "Windows"
         ],
-        "last_renewed": "2017-03-23T17:00:00",
-        "name": "Gajim",
         "url": "https://gajim.org"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "GNU Freetalk",
+        "platforms": [
+            "Linux"
+        ],
         "url": "https://gnufreetalk.github.io/"
     },
     {
-        "info": [
-            "IBM i"
-        ],
         "last_renewed": null,
         "name": "GreenJab",
+        "platforms": [
+            "IBM i"
+        ],
         "url": "http://bvstools.com"
     },
     {
-        "info": [
-            "Mobile"
-        ],
         "last_renewed": null,
         "name": "IM+",
+        "platforms": [
+            "Mobile"
+        ],
         "url": "http://shapeservices.com"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Instantbird",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Instantbird",
         "url": "http://instantbird.com"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "irssi-xmpp",
+        "platforms": [
             "Console",
             "Text-Mode"
         ],
-        "last_renewed": null,
-        "name": "irssi-xmpp",
         "url": "http://cybione.org"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "jabber.el",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://emacs-jabber.sourceforge.net"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Jabbim",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Jabbim",
         "url": "http://jabbim.com"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "JAJC",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://jajc.jrudevels.org"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "Jappix",
+        "platforms": [
+            "Browser"
+        ],
         "url": "http://jappix.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Jitsi",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Jitsi",
         "url": "http://jitsi.org"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": "2017-03-23T13:44:04",
         "name": "JSXC",
+        "platforms": [
+            "Browser"
+        ],
         "url": "https://www.jsxc.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Kadu",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Kadu",
         "url": "http://kadu.net"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "Kaiwa",
+        "platforms": [
+            "Browser"
+        ],
         "url": "http://getkaiwa.com/"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "Kopete",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://kopete.kde.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "mcabber",
+        "platforms": [
             "Console",
             "Text-Mode"
         ],
-        "last_renewed": null,
-        "name": "mcabber",
         "url": "http://mcabber.com"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "Miranda IM",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://miranda-im.org"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "Miranda NG",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://miranda-ng.org"
     },
     {
-        "info": [
-            "iOS"
-        ],
         "last_renewed": null,
         "name": "Monal IM",
+        "platforms": [
+            "iOS"
+        ],
         "url": "http://monal.im"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "Movim",
+        "platforms": [
+            "Browser"
+        ],
         "url": "https://movim.eu"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Mozilla Thunderbird",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Mozilla Thunderbird",
         "url": "http://mozilla.org/thunderbird"
     },
     {
-        "info": [
-            "Linux",
-            "macOS",
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "OneTeam",
-        "url": "http://oneteam.im"
-    },
-    {
-        "info": [
-            "iOS"
-        ],
-        "last_renewed": null,
-        "name": "OneTeam for iPhone",
-        "url": "http://oneteam.im"
-    },
-    {
-        "info": [
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
+        "url": "http://oneteam.im"
+    },
+    {
+        "last_renewed": null,
+        "name": "OneTeam for iPhone",
+        "platforms": [
+            "iOS"
+        ],
+        "url": "http://oneteam.im"
+    },
+    {
         "last_renewed": null,
         "name": "Pidgin",
+        "platforms": [
+            "Linux",
+            "macOS",
+            "Windows"
+        ],
         "url": "http://pidgin.im"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Poezio",
+        "platforms": [
             "Console",
             "Text-Mode"
         ],
-        "last_renewed": null,
-        "name": "Poezio",
         "url": "https://poez.io"
     },
     {
-        "info": [
-            "Windows (Cygwin)",
-            "OSX",
-            "Linux"
-        ],
         "last_renewed": "2017-03-23T20:16:42",
         "name": "Profanity",
+        "platforms": [
+            "Linux",
+            "macOS",
+            "Windows"
+        ],
         "url": "http://profanity.im"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Psi",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Psi",
         "url": "http://psi-im.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Psi+",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Psi+",
         "url": "http://psi-plus.com"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "Quiet Internet Pager",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://forum.qip.ru"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "qutIM",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "qutIM",
         "url": "http://qutim.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Salut \u00e0 Toi",
+        "platforms": [
             "Linux",
             "Console",
             "Text-Mode",
             "Browser"
         ],
-        "last_renewed": null,
-        "name": "Salut \u00e0 Toi",
         "url": "https://salut-a-toi.org/"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "Sim-IM",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://sim-im.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Smuxi",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Smuxi",
         "url": "https://smuxi.im/"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Spark",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Spark",
         "url": "https://igniterealtime.org/projects/spark/index.jsp"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "SparkWeb",
+        "platforms": [
+            "Browser"
+        ],
         "url": "https://igniterealtime.org/projects/sparkweb/index.jsp"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Swift",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Swift",
         "url": "http://swift.im"
     },
     {
-        "info": [
-            "Mobile"
-        ],
         "last_renewed": null,
         "name": "Talkonaut",
+        "platforms": [
+            "Mobile"
+        ],
         "url": "http://talkonaut.com"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "Tigase Messenger",
+        "platforms": [
+            "Browser"
+        ],
         "url": "http://www.tigase.net/content/tigase-messenger-android"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "Tigase Minichat",
+        "platforms": [
+            "Browser"
+        ],
         "url": "http://tigase.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Tkabber",
+        "platforms": [
             "Linux",
             "macOS",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Tkabber",
         "url": "http://tkabber.jabber.ru"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Trillian",
+        "platforms": [
             "Windows",
             "macOS",
             "Mobile",
             "Browser"
         ],
-        "last_renewed": null,
-        "name": "Trillian",
         "url": "http://trillian.im"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "V&V Messenger",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://www.altertech.com/products/vv/"
     },
     {
-        "info": [
-            "BlackBerry"
-        ],
         "last_renewed": null,
         "name": "Vayusphere",
+        "platforms": [
+            "BlackBerry"
+        ],
         "url": "http://vayusphere.com"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "VSTalk",
+        "platforms": [
+            "Windows"
+        ],
         "url": "https://vstalk.codeplex.com/"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "WTW",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://wtw.im/"
     },
     {
-        "info": [
-            "Android"
-        ],
         "last_renewed": null,
         "name": "Xabber",
+        "platforms": [
+            "Android"
+        ],
         "url": "http://xabber.com"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "xmpp-client",
+        "platforms": [
             "Linux",
             "macOS"
         ],
-        "last_renewed": null,
-        "name": "xmpp-client",
         "url": "https://github.com/agl/xmpp-client"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "xmppchat",
+        "platforms": [
+            "Browser"
+        ],
         "url": "http://babelmonkeys.de"
     },
     {
-        "info": [
-            "Browser"
-        ],
         "last_renewed": null,
         "name": "XMPPWebChat",
+        "platforms": [
+            "Browser"
+        ],
         "url": "https://github.com/udayg/xmppwebchat"
     },
     {
-        "info": [
-            "Android"
-        ],
         "last_renewed": "2017-03-23T13:40:52",
         "name": "yaxim",
+        "platforms": [
+            "Android"
+        ],
         "url": "https://yaxim.org"
     }
 ]

--- a/data/clients.json
+++ b/data/clients.json
@@ -73,7 +73,7 @@
         "last_renewed": "2017-03-23T14:02:52",
         "name": "Bruno the Jabber Bear",
         "platforms": [
-            "Mobile (Android)"
+            "Android"
         ],
         "url": "https://yaxim.org/bruno/"
     },

--- a/data/clients.json
+++ b/data/clients.json
@@ -81,9 +81,9 @@
         "last_renewed": null,
         "name": "Buddycloud",
         "platforms": [
+            "Console",
             "Mobile",
-            "Web",
-            "Console"
+            "Web"
         ],
         "url": "http://buddycloud.com"
     },
@@ -432,10 +432,10 @@
         "last_renewed": null,
         "name": "Salut \u00e0 Toi",
         "platforms": [
-            "Linux",
+            "Browser",
             "Console",
-            "Text-Mode",
-            "Browser"
+            "Linux",
+            "Text-Mode"
         ],
         "url": "https://salut-a-toi.org/"
     },
@@ -523,10 +523,10 @@
         "last_renewed": null,
         "name": "Trillian",
         "platforms": [
-            "Windows",
+            "Browser",
             "macOS",
             "Mobile",
-            "Browser"
+            "Windows"
         ],
         "url": "http://trillian.im"
     },

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -3,8 +3,8 @@
         "last_renewed": null,
         "name": "agsXMPP SDK",
         "platforms": [
-            "C#",
             ".net",
+            "C#",
             "Mono"
         ],
         "url": "http://ag-software.net"
@@ -29,8 +29,8 @@
         "last_renewed": null,
         "name": "as3xmpp",
         "platforms": [
-            "Flash",
-            "ActionScript"
+            "ActionScript",
+            "Flash"
         ],
         "url": "https://github.com/lyokato/as3xmppclient"
     },
@@ -70,10 +70,10 @@
         "last_renewed": null,
         "name": "Coversant SoapBox SDK Studio",
         "platforms": [
-            "C#",
             ".net",
-            "Mono",
-            "C++"
+            "C#",
+            "C++",
+            "Mono"
         ],
         "url": "http://coversant.com"
     },
@@ -209,8 +209,8 @@
         "last_renewed": null,
         "name": "jabber.net",
         "platforms": [
-            "C#",
             ".net",
+            "C#",
             "Mono"
         ],
         "url": "https://code.google.com/archive/p/jabber-net/"
@@ -243,9 +243,9 @@
         "last_renewed": null,
         "name": "jaxmpp2",
         "platforms": [
-            "Java",
             "Android",
-            "Google Web Toolkit"
+            "Google Web Toolkit",
+            "Java"
         ],
         "url": "https://projects.tigase.org/projects/jaxmpp2"
     },
@@ -311,8 +311,8 @@
         "last_renewed": null,
         "name": "MatriX",
         "platforms": [
-            "C#",
             ".net",
+            "C#",
             "Mono"
         ],
         "url": "http://ag-software.net"
@@ -377,8 +377,8 @@
         "last_renewed": null,
         "name": "seesmic-as3-xmpp",
         "platforms": [
-            "Flash",
-            "ActionScript"
+            "ActionScript",
+            "Flash"
         ],
         "url": "https://code.google.com/archive/p/seesmic-as3-xmpp"
     },
@@ -386,8 +386,8 @@
         "last_renewed": null,
         "name": "Sharp.Xmpp",
         "platforms": [
-            "C#",
             ".net",
+            "C#",
             "Mono"
         ],
         "url": "https://github.com/pgstath/Sharp.Xmpp"
@@ -500,8 +500,8 @@
         "last_renewed": null,
         "name": "XIFF",
         "platforms": [
-            "Flash",
-            "ActionScript"
+            "ActionScript",
+            "Flash"
         ],
         "url": "http://igniterealtime.org"
     },

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -1,580 +1,580 @@
 [
     {
-        "info": [
+        "last_renewed": null,
+        "name": "agsXMPP SDK",
+        "platforms": [
             "C#",
             ".net",
             "Mono"
         ],
-        "last_renewed": null,
-        "name": "agsXMPP SDK",
         "url": "http://ag-software.net"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": "2017-03-16T07:33:04",
         "name": "aioxmpp",
+        "platforms": [
+            "Python"
+        ],
         "url": "https://github.com/horazont/aioxmpp"
     },
     {
-        "info": [
-            "Perl"
-        ],
         "last_renewed": null,
         "name": "AnyEvent::XMPP",
+        "platforms": [
+            "Perl"
+        ],
         "url": "http://ta-sa.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "as3xmpp",
+        "platforms": [
             "Flash",
             "ActionScript"
         ],
-        "last_renewed": null,
-        "name": "as3xmpp",
         "url": "https://github.com/lyokato/as3xmppclient"
     },
     {
-        "info": [
-            "Ada"
-        ],
         "last_renewed": null,
         "name": "AXMPP",
+        "platforms": [
+            "Ada"
+        ],
         "url": "http://orge.ada-ru.org"
     },
     {
-        "info": [
-            "Java"
-        ],
         "last_renewed": "2017-03-23T18:50:00",
         "name": "Babbler",
+        "platforms": [
+            "Java"
+        ],
         "url": "http://xmpp.rocks"
     },
     {
-        "info": [
-            "Ruby"
-        ],
         "last_renewed": null,
         "name": "Blather",
+        "platforms": [
+            "Ruby"
+        ],
         "url": "http://adhearsion.com"
     },
     {
-        "info": [
-            "Lisp"
-        ],
         "last_renewed": null,
         "name": "cl-xmpp",
+        "platforms": [
+            "Lisp"
+        ],
         "url": "http://common-lisp.net"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Coversant SoapBox SDK Studio",
+        "platforms": [
             "C#",
             ".net",
             "Mono",
             "C++"
         ],
-        "last_renewed": null,
-        "name": "Coversant SoapBox SDK Studio",
         "url": "http://coversant.com"
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": null,
         "name": "dojox.xmpp",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "https://github.com/dojo/dojox"
     },
     {
-        "info": [
-            "C++"
-        ],
         "last_renewed": null,
         "name": "dxmpp",
+        "platforms": [
+            "C++"
+        ],
         "url": "https://github.com/stefandxm/dxmpp"
     },
     {
-        "info": [
-            "Java"
-        ],
         "last_renewed": null,
         "name": "Echomine Feridian",
+        "platforms": [
+            "Java"
+        ],
         "url": "https://github.com/jdevelop/feridian"
     },
     {
-        "info": [
-            "PHP"
-        ],
         "last_renewed": null,
         "name": "Eiffel",
+        "platforms": [
+            "PHP"
+        ],
         "url": "https://www.eiffel.org/resources/libraries/eiffel-xmpp"
     },
     {
-        "info": [
-            "Java"
-        ],
         "last_renewed": null,
         "name": "emite",
+        "platforms": [
+            "Java"
+        ],
         "url": "https://github.com/EmiteGWT/emite"
     },
     {
-        "info": [
-            "Erlang"
-        ],
         "last_renewed": null,
         "name": "Escalus",
+        "platforms": [
+            "Erlang"
+        ],
         "url": "https://github.com/esl/escalus"
     },
     {
-        "info": [
-            "Erlang"
-        ],
         "last_renewed": null,
         "name": "exmpp",
+        "platforms": [
+            "Erlang"
+        ],
         "url": "http://exmpp.org"
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": null,
         "name": "frabjous",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "https://github.com/theozaurus/frabjous"
     },
     {
-        "info": [
-            "C++"
-        ],
         "last_renewed": null,
         "name": "gloox",
+        "platforms": [
+            "C++"
+        ],
         "url": "http://camaya.net"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": null,
         "name": "headstock",
+        "platforms": [
+            "Python"
+        ],
         "url": "https://github.com/Lawouach/headstock"
     },
     {
-        "info": [
-            "Haskell"
-        ],
         "last_renewed": null,
         "name": "hsxmpp",
+        "platforms": [
+            "Haskell"
+        ],
         "url": "http://\u05d7\u05e0\u05d5\u05da.se"
     },
     {
-        "info": [
-            "haXe"
-        ],
         "last_renewed": null,
         "name": "hxmpp",
+        "platforms": [
+            "haXe"
+        ],
         "url": "http://hxmpp.disktree.net"
     },
     {
-        "info": [
-            "C"
-        ],
         "last_renewed": null,
         "name": "iksemel",
+        "platforms": [
+            "C"
+        ],
         "url": "http://code.google.com/p/iksemel"
     },
     {
-        "info": [
-            "ActiveX, C++, C#,"
-        ],
         "last_renewed": null,
         "name": "IP*Works Internet Toolkit",
+        "platforms": [
+            "ActiveX, C++, C#,"
+        ],
         "url": "https://www.nsoftware.com/ipworks/"
     },
     {
-        "info": [
-            "C++"
-        ],
         "last_renewed": null,
         "name": "Iris",
+        "platforms": [
+            "C++"
+        ],
         "url": "https://github.com/psi-im/iris"
     },
     {
-        "info": [
-            "Java"
-        ],
         "last_renewed": null,
         "name": "Jabber Stream Objects (JSO)",
+        "platforms": [
+            "Java"
+        ],
         "url": "https://java.net/projects/jso"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "jabber.net",
+        "platforms": [
             "C#",
             ".net",
             "Mono"
         ],
-        "last_renewed": null,
-        "name": "jabber.net",
         "url": "https://code.google.com/archive/p/jabber-net/"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": null,
         "name": "jabber.py",
+        "platforms": [
+            "Python"
+        ],
         "url": "http://jabberpy.sourceforge.net/"
     },
     {
-        "info": [
-            "Tcl"
-        ],
         "last_renewed": null,
         "name": "JabberLib",
+        "platforms": [
+            "Tcl"
+        ],
         "url": "http://coccinella.im"
     },
     {
-        "info": [
-            "PHP"
-        ],
         "last_renewed": null,
         "name": "JAXL",
+        "platforms": [
+            "PHP"
+        ],
         "url": "https://github.com/jaxl/JAXL"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "jaxmpp2",
+        "platforms": [
             "Java",
             "Android",
             "Google Web Toolkit"
         ],
-        "last_renewed": null,
-        "name": "jaxmpp2",
         "url": "https://projects.tigase.org/projects/jaxmpp2"
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": null,
         "name": "jQuery-XMPP-plugin",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "https://github.com/maxpowel/jQuery-XMPP-plugin"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Jreen",
+        "platforms": [
             "C++",
             "Qt"
         ],
-        "last_renewed": null,
-        "name": "Jreen",
         "url": "http://qutim.org"
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": null,
         "name": "JSJaC",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "https://github.com/sstrigler/JSJaC"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "libpurple",
+        "platforms": [
             "C",
             "C++"
         ],
-        "last_renewed": null,
-        "name": "libpurple",
         "url": "https://developer.pidgin.im/wiki/WhatIsLibpurple"
     },
     {
-        "info": [
-            "C"
-        ],
         "last_renewed": null,
         "name": "libstrophe",
+        "platforms": [
+            "C"
+        ],
         "url": "http://strophe.im"
     },
     {
-        "info": [
-            "PHP"
-        ],
         "last_renewed": null,
         "name": "Lightr",
+        "platforms": [
+            "PHP"
+        ],
         "url": "https://github.com/myYearbook/lightr"
     },
     {
-        "info": [
-            "C"
-        ],
         "last_renewed": null,
         "name": "Loudmouth",
+        "platforms": [
+            "C"
+        ],
         "url": "https://github.com/mcabber/loudmouth"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "MatriX",
+        "platforms": [
             "C#",
             ".net",
             "Mono"
         ],
-        "last_renewed": null,
-        "name": "MatriX",
         "url": "http://ag-software.net"
     },
     {
-        "info": [
-            "Perl"
-        ],
         "last_renewed": null,
         "name": "net::XMPP",
+        "platforms": [
+            "Perl"
+        ],
         "url": null
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": null,
         "name": "node-xmpp",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "http://node-xmpp.org"
     },
     {
-        "info": [
-            "C++"
-        ],
         "last_renewed": null,
         "name": "oajabber",
+        "platforms": [
+            "C++"
+        ],
         "url": null
     },
     {
-        "info": [
-            "Haskell"
-        ],
         "last_renewed": null,
         "name": "Pontarius XMPP",
+        "platforms": [
+            "Haskell"
+        ],
         "url": "https://github.com/pontarius/pontarius-xmpp/"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": null,
         "name": "pyxmpp",
+        "platforms": [
+            "Python"
+        ],
         "url": "http://pyxmpp.jajcus.net/pyxmpp.html"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": null,
         "name": "pyxmpp2",
+        "platforms": [
+            "Python"
+        ],
         "url": "https://github.com/Jajcus/pyxmpp2"
     },
     {
-        "info": [
-            "C++"
-        ],
         "last_renewed": null,
         "name": "QXmpp",
+        "platforms": [
+            "C++"
+        ],
         "url": "www.qxmpp.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "seesmic-as3-xmpp",
+        "platforms": [
             "Flash",
             "ActionScript"
         ],
-        "last_renewed": null,
-        "name": "seesmic-as3-xmpp",
         "url": "https://code.google.com/archive/p/seesmic-as3-xmpp"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Sharp.Xmpp",
+        "platforms": [
             "C#",
             ".net",
             "Mono"
         ],
-        "last_renewed": null,
-        "name": "Sharp.Xmpp",
         "url": "https://github.com/pgstath/Sharp.Xmpp"
     },
     {
-        "info": [
-            "Ruby"
-        ],
         "last_renewed": null,
         "name": "Skates",
+        "platforms": [
+            "Ruby"
+        ],
         "url": "https://github.com/julien51/skates"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": null,
         "name": "SleekXMPP",
+        "platforms": [
+            "Python"
+        ],
         "url": "https://github.com/fritzy/SleekXMPP"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": null,
         "name": "Slixmpp",
+        "platforms": [
+            "Python"
+        ],
         "url": "https://dev.louiz.org/projects/slixmpp"
     },
     {
-        "info": [
-            "Java (Java SE and Android)"
-        ],
         "last_renewed": "2017-03-22T00:00:00",
         "name": "Smack",
+        "platforms": [
+            "Java (Java SE and Android)"
+        ],
         "url": "https://www.igniterealtime.org/projects/smack"
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": null,
         "name": "stanza.io",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "https://github.com/otalk/stanza.io"
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": null,
         "name": "strophe.js",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "http://strophe.im/strophejs"
     },
     {
-        "info": [
-            "Objective-J"
-        ],
         "last_renewed": null,
         "name": "StropheCappuccino",
+        "platforms": [
+            "Objective-J"
+        ],
         "url": "https://github.com/ArchipelProject/StropheCappuccino"
     },
     {
-        "info": [
-            "C++"
-        ],
         "last_renewed": null,
         "name": "Swiften",
+        "platforms": [
+            "C++"
+        ],
         "url": "http://swift.im"
     },
     {
-        "info": [
-            "Java"
-        ],
         "last_renewed": null,
         "name": "Tinder",
+        "platforms": [
+            "Java"
+        ],
         "url": "http://www.igniterealtime.org/projects/tinder"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": null,
         "name": "Twisted Words",
+        "platforms": [
+            "Python"
+        ],
         "url": "http://twistedmatrix.com"
     },
     {
-        "info": [
-            "C++"
-        ],
         "last_renewed": null,
         "name": "txmpp",
+        "platforms": [
+            "C++"
+        ],
         "url": "https://github.com/rpavlik/txmpp"
     },
     {
-        "info": [
-            "C#"
-        ],
         "last_renewed": null,
         "name": "Ubeity",
+        "platforms": [
+            "C#"
+        ],
         "url": "https://github.com/ubiety/xmpp"
     },
     {
-        "info": [
-            "Lua"
-        ],
         "last_renewed": null,
         "name": "Verse",
+        "platforms": [
+            "Lua"
+        ],
         "url": "http://www.matthewwild.co.uk/projects/verse/home"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "XIFF",
+        "platforms": [
             "Flash",
             "ActionScript"
         ],
-        "last_renewed": null,
-        "name": "XIFF",
         "url": "http://igniterealtime.org"
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": "2017-03-24T00:00:00",
         "name": "XMPP-FTW",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "https://github.com/xmpp-ftw"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": null,
         "name": "xmpp-psn",
+        "platforms": [
+            "Python"
+        ],
         "url": "http://code.google.com"
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": null,
         "name": "xmpp4js",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "http://xmpp4js.sourceforge.net/"
     },
     {
-        "info": [
-            "Ruby"
-        ],
         "last_renewed": null,
         "name": "XMPP4R",
+        "platforms": [
+            "Ruby"
+        ],
         "url": "https://xmpp4r.github.io/"
     },
     {
-        "info": [
-            "Ruby"
-        ],
         "last_renewed": null,
         "name": "xmpp4r-simple",
+        "platforms": [
+            "Ruby"
+        ],
         "url": "http://code.google.com"
     },
     {
-        "info": [
-            "Objective C"
-        ],
         "last_renewed": null,
         "name": "xmppframework",
+        "platforms": [
+            "Objective C"
+        ],
         "url": "http://github.com"
     },
     {
-        "info": [
-            "PHP"
-        ],
         "last_renewed": null,
         "name": "xmpphp",
+        "platforms": [
+            "PHP"
+        ],
         "url": "http://code.google.com"
     },
     {
-        "info": [
-            "Python"
-        ],
         "last_renewed": null,
         "name": "xmpppy",
+        "platforms": [
+            "Python"
+        ],
         "url": "http://xmpppy.sourceforge.net"
     },
     {
-        "info": [
-            "JavaScript"
-        ],
         "last_renewed": null,
         "name": "Z-XMPP",
+        "platforms": [
+            "JavaScript"
+        ],
         "url": "http://ivan.vucica.net"
     }
 ]

--- a/data/lint-list.py
+++ b/data/lint-list.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import json
+import os.path
+import sys
+
+from datetime import datetime
+
+
+VALID_ENTRY_KEYS = {
+    "platforms",
+    "name",
+    "last_renewed",
+    "url",
+}
+
+
+def emit_violation(entry_name, message):
+    print(
+        "ERROR: entry {!r}: {}".format(
+            entry_name,
+            message,
+        ),
+        file=sys.stderr,
+    )
+
+
+def check_entries(entries, allowed_platforms=None):
+    violations = 0
+    previous_name = None
+    previous_key = None
+    for entry in entries:
+        key = entry["name"].casefold()
+        if previous_key is not None and previous_key > key:
+            emit_violation(
+                entry["name"],
+                "should be placed behind {!r}".format(
+                    previous_name
+                )
+            )
+            violations += 1
+
+        entry_keys = set(entry.keys())
+        unknown = entry_keys - VALID_ENTRY_KEYS
+        missing = VALID_ENTRY_KEYS - entry_keys
+
+        if unknown:
+            emit_violation(
+                entry["name"],
+                "has unknown keys: {}".format(
+                    ", ".join(map(repr, unknown))
+                )
+            )
+            violations += 1
+
+        if missing:
+            emit_violation(
+                entry["name"],
+                "misses required information: {}".format(
+                    ", ".join(map(repr, missing))
+                )
+            )
+            violations += 1
+
+        if entry.get("last_renewed") is not None:
+            try:
+                datetime.strptime(entry["last_renewed"],
+                                  "%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                emit_violation(
+                    entry["name"],
+                    "malformed renewal timestamp: {!r}".format(
+                        entry["last_renewed"],
+                    )
+                )
+                violations += 1
+
+        platforms = entry.get("platforms", [])
+
+        if (allowed_platforms is not None and
+                entry.get("last_renewed") is not None):
+            unknown = set(platforms) - allowed_platforms
+            if unknown:
+                emit_violation(
+                    entry["name"],
+                    "undefined platforms: {}".format(
+                        ", ".join(map(repr, unknown)),
+                    ),
+                )
+                violations += 1
+
+        previous_key, previous_name = key, entry["name"]
+
+    return violations
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "which",
+        choices=("clients.json", "servers.json", "libraries.json"),
+    )
+
+    args = parser.parse_args()
+
+    base_path = os.path.dirname(os.path.abspath(sys.argv[0]))
+    input_file = os.path.join(base_path, "{}".format(args.which))
+    platforms_file = os.path.join(base_path, "platforms.json")
+
+    with open(input_file, "r") as f:
+        data = json.load(f)
+
+    if args.which in ["clients.json"]:
+        with open(platforms_file, "r") as f:
+            platforms = set(json.load(f))
+    else:
+        platforms = None
+
+    violations = check_entries(data, allowed_platforms=platforms)
+    if violations:
+        print("Found {} severe violations. "
+              "Please fix them.".format(violations),
+              file=sys.stderr)
+        sys.exit(1)

--- a/data/lint-list.py
+++ b/data/lint-list.py
@@ -88,6 +88,16 @@ def check_entries(entries, allowed_platforms=None):
                 )
                 violations += 1
 
+        sorted_platforms = sorted(platforms, key=lambda x: x.casefold())
+        if sorted_platforms != platforms:
+            emit_violation(
+                entry["name"],
+                "platform order must be: {}".format(
+                    ", ".join(map(repr, sorted_platforms))
+                )
+            )
+            violations += 1
+
         previous_key, previous_name = key, entry["name"]
 
     return violations

--- a/data/lint-list.py
+++ b/data/lint-list.py
@@ -37,7 +37,8 @@ def check_entries(entries,
         if previous_key is not None and previous_key > key:
             emit_violation(
                 entry["name"],
-                "should be placed behind {!r}".format(
+                "should be placed behind {!r} (all entries must be "
+                "ordered alphabetically by case-folded name)".format(
                     previous_name
                 )
             )
@@ -59,7 +60,8 @@ def check_entries(entries,
         if missing:
             emit_violation(
                 entry["name"],
-                "misses required information: {}".format(
+                "misses the following required properties: {} "
+                "(see other entries for a reference)".format(
                     ", ".join(map(repr, missing))
                 )
             )
@@ -72,7 +74,8 @@ def check_entries(entries,
             except ValueError:
                 emit_violation(
                     entry["name"],
-                    "malformed renewal timestamp: {!r}".format(
+                    "malformed renewal timestamp: {!r} "
+                    "(format is YYYY-MM-DDThh:mm:ss)".format(
                         entry["last_renewed"],
                     )
                 )
@@ -86,7 +89,10 @@ def check_entries(entries,
             if unknown and (is_severe or show_warnings):
                 emit_violation(
                     entry["name"],
-                    "undefined platforms: {}".format(
+                    "undefined platforms: {} "
+                    "(the allowed platforms are listed in platforms.json. If"
+                    " you think a platform is missing add it and mention it "
+                    "in your Pull Request)".format(
                         ", ".join(map(repr, unknown)),
                     ),
                     warning=not is_severe
@@ -97,7 +103,8 @@ def check_entries(entries,
         if sorted_platforms != platforms:
             emit_violation(
                 entry["name"],
-                "platform order must be: {}".format(
+                "platform order must be: {} "
+                "(platforms must be ordered alphabetically)".format(
                     ", ".join(map(repr, sorted_platforms))
                 )
             )

--- a/data/lint-list.py
+++ b/data/lint-list.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     with open(input_file, "r") as f:
         data = json.load(f)
 
-    if args.which in ["clients.json"]:
+    if args.which in ["clients.json", "servers.json"]:
         with open(platforms_file, "r") as f:
             platforms = set(json.load(f))
     else:

--- a/data/platforms.json
+++ b/data/platforms.json
@@ -1,0 +1,9 @@
+[
+    "Android",
+    "Browser",
+    "iOS",
+    "Linux",
+    "macOS",
+    "Windows",
+    "Other Mobile"
+]

--- a/data/platforms.json
+++ b/data/platforms.json
@@ -1,9 +1,11 @@
 [
     "Android",
     "Browser",
+    "BSD",
     "iOS",
     "Linux",
     "macOS",
-    "Windows",
-    "Other Mobile"
+    "Other",
+    "Solaris",
+    "Windows"
 ]

--- a/data/servers.json
+++ b/data/servers.json
@@ -1,234 +1,234 @@
 [
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Apache Vysper",
+        "platforms": [
             "Windows",
             "Linux"
         ],
-        "last_renewed": null,
-        "name": "Apache Vysper",
         "url": "https://mina.apache.org/vysper-project"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "Citadel",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://citadel.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "CommuniGate Pro",
+        "platforms": [
             "Linux",
             "Mac OS X",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "CommuniGate Pro",
         "url": "http://communigate.com"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "Coversant SoapBox Server",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://coversant.com"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "djabberd",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://danga.com"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "ejabberd",
+        "platforms": [
             "Linux",
             "Mac OS X",
             "Solaris",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "ejabberd",
         "url": "http://process-one.net"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "IceWarp",
+        "platforms": [
             "Linux",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "IceWarp",
         "url": "http://icewarp.com"
     },
     {
-        "info": [
-            "Mac OS X"
-        ],
         "last_renewed": null,
         "name": "iChat Server",
+        "platforms": [
+            "Mac OS X"
+        ],
         "url": "http://apple.com"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "in.jabberd",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://inetdxtra.sourceforge.net"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Isode M-Link",
+        "platforms": [
             "Linux",
             "Solaris",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Isode M-Link",
         "url": "http://isode.com"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Jabber XCP",
+        "platforms": [
             "Linux",
             "Solaris",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Jabber XCP",
         "url": "http://cisco.com"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "jabberd 1.x",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://jabberd.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "jabberd 2.x",
+        "platforms": [
             "Linux",
             "*BSD",
             "Solaris",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "jabberd 2.x",
         "url": "http://jabberd2.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Jerry Messenger",
+        "platforms": [
             "Linux",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Jerry Messenger",
         "url": "http://j-livesupport.com"
     },
     {
-        "info": [
-            "Windows"
-        ],
         "last_renewed": null,
         "name": "Kwickserver",
+        "platforms": [
+            "Windows"
+        ],
         "url": "http://kwickserver.info"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Metronome IM",
+        "platforms": [
             "Linux",
             "Mac OS X"
         ],
-        "last_renewed": null,
-        "name": "Metronome IM",
         "url": "http://lightwitch.org/metronome"
     },
     {
-        "info": [
+        "last_renewed": "2017-03-23T19:39:28",
+        "name": "MongooseIM",
+        "platforms": [
             "Linux",
             "Mac OS X"
         ],
-        "last_renewed": "2017-03-23T19:39:28",
-        "name": "MongooseIM",
         "url": "https://www.erlang-solutions.com/products/mongooseim.html"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Openfire",
+        "platforms": [
             "Linux",
             "Mac OS X",
             "Solaris",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Openfire",
         "url": "http://igniterealtime.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Oracle Communications IM Server",
+        "platforms": [
             "Linux",
             "Solaris",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Oracle Communications IM Server",
         "url": "http://oracle.com"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Prosody IM",
+        "platforms": [
             "Linux",
             "Mac OS X",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Prosody IM",
         "url": "http://prosody.im"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "psyced",
+        "platforms": [
             "Linux",
             "Mac OS X",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "psyced",
         "url": "http://psyced.org"
     },
     {
-        "info": [
-            "Linux"
-        ],
         "last_renewed": null,
         "name": "Siemens OpenScape",
+        "platforms": [
+            "Linux"
+        ],
         "url": "http://siemens-enterprise.com"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Tigase",
+        "platforms": [
             "Linux",
             "Solaris",
             "Mac OS X",
             "Windows"
         ],
-        "last_renewed": null,
-        "name": "Tigase",
         "url": "http://tigase.org"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Vines",
+        "platforms": [
             "Linux",
             "Mac OS X"
         ],
-        "last_renewed": null,
-        "name": "Vines",
         "url": "http://getvines.com"
     },
     {
-        "info": [
+        "last_renewed": null,
+        "name": "Wokkel",
+        "platforms": [
             "Linux",
             "Solaris",
             "Mac OS X"
         ],
-        "last_renewed": null,
-        "name": "Wokkel",
         "url": "http://wokkel.ik.nu"
     }
 ]

--- a/data/servers.json
+++ b/data/servers.json
@@ -3,8 +3,8 @@
         "last_renewed": null,
         "name": "Apache Vysper",
         "platforms": [
-            "Windows",
-            "Linux"
+            "Linux",
+            "Windows"
         ],
         "url": "https://mina.apache.org/vysper-project"
     },
@@ -21,7 +21,7 @@
         "name": "CommuniGate Pro",
         "platforms": [
             "Linux",
-            "Mac OS X",
+            "macOS",
             "Windows"
         ],
         "url": "http://communigate.com"
@@ -47,7 +47,7 @@
         "name": "ejabberd",
         "platforms": [
             "Linux",
-            "Mac OS X",
+            "macOS",
             "Solaris",
             "Windows"
         ],
@@ -66,7 +66,7 @@
         "last_renewed": null,
         "name": "iChat Server",
         "platforms": [
-            "Mac OS X"
+            "macOS"
         ],
         "url": "http://apple.com"
     },
@@ -110,8 +110,8 @@
         "last_renewed": null,
         "name": "jabberd 2.x",
         "platforms": [
+            "BSD",
             "Linux",
-            "*BSD",
             "Solaris",
             "Windows"
         ],
@@ -139,7 +139,7 @@
         "name": "Metronome IM",
         "platforms": [
             "Linux",
-            "Mac OS X"
+            "macOS"
         ],
         "url": "http://lightwitch.org/metronome"
     },
@@ -148,7 +148,7 @@
         "name": "MongooseIM",
         "platforms": [
             "Linux",
-            "Mac OS X"
+            "macOS"
         ],
         "url": "https://www.erlang-solutions.com/products/mongooseim.html"
     },
@@ -157,7 +157,7 @@
         "name": "Openfire",
         "platforms": [
             "Linux",
-            "Mac OS X",
+            "macOS",
             "Solaris",
             "Windows"
         ],
@@ -178,7 +178,7 @@
         "name": "Prosody IM",
         "platforms": [
             "Linux",
-            "Mac OS X",
+            "macOS",
             "Windows"
         ],
         "url": "http://prosody.im"
@@ -188,7 +188,7 @@
         "name": "psyced",
         "platforms": [
             "Linux",
-            "Mac OS X",
+            "macOS",
             "Windows"
         ],
         "url": "http://psyced.org"
@@ -206,8 +206,8 @@
         "name": "Tigase",
         "platforms": [
             "Linux",
+            "macOS",
             "Solaris",
-            "Mac OS X",
             "Windows"
         ],
         "url": "http://tigase.org"
@@ -217,7 +217,7 @@
         "name": "Vines",
         "platforms": [
             "Linux",
-            "Mac OS X"
+            "macOS"
         ],
         "url": "http://getvines.com"
     },
@@ -226,8 +226,8 @@
         "name": "Wokkel",
         "platforms": [
             "Linux",
-            "Solaris",
-            "Mac OS X"
+            "macOS",
+            "Solaris"
         ],
         "url": "http://wokkel.ik.nu"
     }

--- a/data/update-entry.py
+++ b/data/update-entry.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python3
 import argparse
+import difflib
 import copy
 import json
 import sys
 
 from datetime import datetime
+
+
+def json_as_lines(data):
+    return [
+        line+"\n"
+        for line in json.dumps(
+                data,
+                indent=4,
+                sort_keys=True
+        ).split("\n")
+    ]
 
 
 def main():
@@ -122,13 +134,19 @@ def main():
         ).isoformat()
 
     if args.ask:
-        print("old entry:")
-        json.dump(orig, sys.stdout, indent=4, sort_keys=True)
-        print()
-        print()
-        print("new entry:")
-        json.dump(item, sys.stdout, indent=4, sort_keys=True)
-        print()
+        old_entry = json_as_lines(orig)
+        new_entry = json_as_lines(item)
+        print("difference between old and new:")
+        sys.stdout.writelines(
+            difflib.unified_diff(
+                old_entry,
+                new_entry,
+                fromfile="before",
+                tofile="after",
+                n=1000,
+            )
+        )
+
         prompt = "is this okay? [y/n]"
         try:
             chosen = input(prompt)

--- a/data/update-entry.py
+++ b/data/update-entry.py
@@ -42,9 +42,9 @@ def main():
     )
 
     parser.add_argument(
-        "--set-info",
-        dest="new_info",
-        metavar="INFO",
+        "--set-platforms",
+        dest="new_platforms",
+        metavar="PLATFORM",
         default=None,
         nargs="+",
         help="Change the contents of the last column",
@@ -112,9 +112,9 @@ def main():
     if args.new_url is not None:
         item["url"] = args.new_url or None
 
-    if args.new_info is not None:
-        item["info"] = [info_item.strip()
-                        for info_item in args.new_info]
+    if args.new_platforms is not None:
+        item["platforms"] = [platform.strip()
+                             for platform in args.new_platforms]
 
     if args.renew:
         item["last_renewed"] = datetime.utcnow().replace(

--- a/data/update-entry.py
+++ b/data/update-entry.py
@@ -19,6 +19,10 @@ def json_as_lines(data):
     ]
 
 
+def sortkey(x):
+    return x.casefold()
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Renew a software entry in the software list."
@@ -127,6 +131,8 @@ def main():
     if args.new_platforms is not None:
         item["platforms"] = [platform.strip()
                              for platform in args.new_platforms]
+
+    item["platforms"].sort(key=lambda x: x.casefold())
 
     if args.renew:
         item["last_renewed"] = datetime.utcnow().replace(

--- a/xmpp.org-theme/templates/software_list.html
+++ b/xmpp.org-theme/templates/software_list.html
@@ -6,7 +6,7 @@
     <table>
       <thead>
         <th>Project Name</th>
-        <th>{{ page.swlist_info_column_head | default("Platforms") }}</th>
+        <th>{{ page.swlist_platforms_column_head | default("Platforms") }}</th>
       </thead>
       <tbody>
         {% for item in data | sort(attribute='name') %}
@@ -14,7 +14,7 @@
             <td>{% if item.url %}
               <a href="{{ item.url }}">{{ item.name }}</a>
             {% else %}{{ item.name }}{% endif %}</td>
-            <td>{{ item.info | join(" / ") }}</td>
+            <td>{{ item.platforms | join(" / ") }}</td>
           </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
This includes several things discussed in the xsf@ MUC.

1. a linting tool (``lint-list.py``)
2. ``update-entry.py`` now shows the changes as a diff instead of side-by-side
3. the platforms which can be used for clients and servers are defined in ``platforms.json`` and they’re enforced by the linting tool (only for renewed entries) and ``update-entry.py``.
4. rename the ``"info"`` field to ``"platforms"`` in the JSON (which needs changes in the templates and page files). This has the advantage to be clearer in the tooling and sorting more nicely in the JSON output.

The readme has been updated.