### PR TITLE
Improve links to blog articles from overview

### DIFF
--- a/xmpp.org-theme/templates/index.html
+++ b/xmpp.org-theme/templates/index.html
@@ -12,7 +12,7 @@
     <h1><a href="{{ SITE_URL}}/{{ article.url }}">{{ article.title }}</a></h1>
     {{ article.summary }}
     <p>
-      <a href="{{ SITE_URL }}/{{ article.url }}">Continue reading &raquo;</a>
+      <a href="{{ SITE_URL }}/{{ article.url }}">Continue reading {{ article.title }}&raquo;</a>
     </p>
     <h6>
       Posted by

--- a/xmpp.org-theme/templates/index.html
+++ b/xmpp.org-theme/templates/index.html
@@ -12,7 +12,7 @@
     <h1><a href="{{ SITE_URL}}/{{ article.url }}">{{ article.title }}</a></h1>
     {{ article.summary }}
     <p>
-      <a href="{{ SITE_URL }}/{{ article.url }}">Continue reading {{ article.title }}&raquo;</a>
+      <a href="{{ SITE_URL }}/{{ article.url }}">Continue reading &ldquo;{{ article.title }}&rdquo; &raquo;</a>
     </p>
     <h6>
       Posted by

--- a/xmpp.org-theme/templates/index.html
+++ b/xmpp.org-theme/templates/index.html
@@ -9,7 +9,7 @@
 {% endblock %}
 {% for article in articles_page.object_list %}
   <article>
-    <h1>{{ article.title }}</h1>
+    <h1><a href="{{ SITE_URL}}/{{ article.url }}">{{ article.title }}</a></h1>
     {{ article.summary }}
     <p>
       <a href="{{ SITE_URL }}/{{ article.url }}">Continue reading &raquo;</a>


### PR DESCRIPTION
1. Make the heading of the blog article clickable
2. Include the title of the blog article in the "Continue reading" link: This is due to an accessibility recommendation to not have two links with the same text point to different URLs.

Note: This changes the colour of the headings in the overview because they are now links and that takes precedence of the heading colour. I cannot into SASS, so I haven’t changed that.

![Screenshot](https://cloud.githubusercontent.com/assets/271710/24288258/f125369c-107c-11e7-927c-70d78be1ed0a.png)

