### PR TITLE
ProcessOne renewals

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -161,10 +161,9 @@
             "Linux",
             "Other",
             "Windows"
-
         ],
         "url": "http://eyecu.ru"
-    },    
+    },
     {
         "last_renewed": null,
         "name": "Finch",
@@ -355,20 +354,12 @@
         "url": "http://mozilla.org/thunderbird"
     },
     {
-        "last_renewed": null,
+        "last_renewed": "2017-04-14T12:37:30",
         "name": "OneTeam",
         "platforms": [
             "Linux",
             "macOS",
             "Windows"
-        ],
-        "url": "http://oneteam.im"
-    },
-    {
-        "last_renewed": null,
-        "name": "OneTeam for iPhone",
-        "platforms": [
-            "iOS"
         ],
         "url": "http://oneteam.im"
     },

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -118,6 +118,15 @@
         "url": "https://github.com/EmiteGWT/emite"
     },
     {
+        "last_renewed": "2017-04-14T12:42:04",
+        "name": "Erlang/Elixir XMPP",
+        "platforms": [
+            "Elixir",
+            "Erlang"
+        ],
+        "url": "https://github.com/processone/xmpp"
+    },
+    {
         "last_renewed": null,
         "name": "Escalus",
         "platforms": [

--- a/data/servers.json
+++ b/data/servers.json
@@ -43,15 +43,14 @@
         "url": "http://danga.com"
     },
     {
-        "last_renewed": null,
+        "last_renewed": "2017-04-14T12:38:21",
         "name": "ejabberd",
         "platforms": [
             "Linux",
             "macOS",
-            "Solaris",
             "Windows"
         ],
-        "url": "http://process-one.net"
+        "url": "https://www.process-one.net/en/ejabberd"
     },
     {
         "last_renewed": null,


### PR DESCRIPTION
Renewed: ejabberd server, OneTeam client. Removed discontinued OneTeam
for iPhone client. Added Erlang/Elixir library.