### PR TITLE
software/libraries: Update gloox last_renewed

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -140,7 +140,7 @@
         "url": "https://github.com/theozaurus/frabjous"
     },
     {
-        "last_renewed": null,
+        "last_renewed": "2017-08-03T10:19:16",
         "name": "gloox",
         "platforms": [
             "C++"
@@ -304,7 +304,7 @@
             "C"
         ],
         "url": "https://github.com/mcabber/loudmouth"
-    },   
+    },
     {
         "last_renewed": "2017-03-29T00:33:45",
         "name": "MatriX",


### PR DESCRIPTION
I'm not the author of the library, but the last update is less than a year ago and I wanted to update this here. The date I've set is the latest release date (2017.02.26 / 1.0.20). Is this correct, or should it be the current date?