### PR TITLE
Apply for trademark sublicense for JabberCat

### DIFF
--- a/content/pages/about/xsf/jabber-trademark/approved-applications.md
+++ b/content/pages/about/xsf/jabber-trademark/approved-applications.md
@@ -45,7 +45,7 @@ This page lists licensed uses of the [Jabber trademark](/about/xsf/jabber-tradem
 | Jabber GG Transport                   | Jacek Konieczny             | Open-Source Project         | 2006-01-13    |
 | Jabber Mail Component                 | David Rousselie             | Open-Source Project         | 2006-01-13    |
 | Jabber Registration Tool              | Rene Bartosh                | Open-Source Project         | 2006-01-13    |
-| JabberCat                             | Jonas Wielicki              | Open-Source Project         | TBD           |
+| JabberCat                             | Jonas Wielicki              | Open-Source Project         | 2017-09-13    |
 | jabberd                               | Rob Norris                  | Open-Source Project         | 2004-03-09    |
 | JabberNuke                            | maketheweb.com              | For-Profit Company          | 2006-01-13    |
 | JabberStudio                          | Thomas Muldowney            | Open-Source Project         | 2004-06-24    |

--- a/content/pages/about/xsf/jabber-trademark/approved-applications.md
+++ b/content/pages/about/xsf/jabber-trademark/approved-applications.md
@@ -45,6 +45,7 @@ This page lists licensed uses of the [Jabber trademark](/about/xsf/jabber-tradem
 | Jabber GG Transport                   | Jacek Konieczny             | Open-Source Project         | 2006-01-13    |
 | Jabber Mail Component                 | David Rousselie             | Open-Source Project         | 2006-01-13    |
 | Jabber Registration Tool              | Rene Bartosh                | Open-Source Project         | 2006-01-13    |
+| JabberCat                             | Jonas Wielicki              | Open-Source Project         | TBD           |
 | jabberd                               | Rob Norris                  | Open-Source Project         | 2004-03-09    |
 | JabberNuke                            | maketheweb.com              | For-Profit Company          | 2006-01-13    |
 | JabberStudio                          | Thomas Muldowney            | Open-Source Project         | 2004-06-24    |


### PR DESCRIPTION
The personal details have been supplied to trademark@jabber.org, hopefully reaching @stpeter as intended. If not, please let me know via email (jonas@wielicki.name) or other means.

(See also #200, if you’re wondering on why this PR was made and how that fits into the trademark process.)