### PR TITLE
Update clients.json

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -99,7 +99,6 @@
         "last_renewed": "2017-04-19T14:37:00",
         "name": "ChatSecure",
         "platforms": [
-            "Android",
             "iOS"
         ],
         "url": "https://chatsecure.org/"


### PR DESCRIPTION
ChatSecure does not support Android anymore, amended list to reflect that.

More info: https://chatsecure.org/faq/