### PR TITLE
Add Kaidan to clients list

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -297,8 +297,8 @@
         "last_renewed": "2018-06-06T20:15:00",
         "name": "Kaidan",
         "platforms": [
-            "Linux",
-            "Android"
+            "Android",
+            "Linux"
         ],
         "url": "https://git.kaidan.im/kaidan/kaidan"
     },

--- a/data/clients.json
+++ b/data/clients.json
@@ -294,6 +294,15 @@
         "url": "http://kadu.net"
     },
     {
+        "last_renewed": "2018-06-06T20:15:00",
+        "name": "Kaidan",
+        "platforms": [
+            "Linux",
+            "Android"
+        ],
+        "url": "https://git.kaidan.im/kaidan/kaidan"
+    },
+    {
         "last_renewed": null,
         "name": "Kaiwa",
         "platforms": [


### PR DESCRIPTION
Theoretically Kaidan also compiles for macOS, Windows and iOS, but these are not tested. Also, Kaidan is running on Plasma Mobile - Is there a need for adding smth. as `Linux Mobile` / `Plasma Mobile` as platform?