### PR TITLE
Add 404.city Supports all useful XEPs

### DIFF
--- a/content/pages/getting-started/_index.md
+++ b/content/pages/getting-started/_index.md
@@ -31,6 +31,7 @@ As with e-mail, you'll need an account with a service provider. Again, there are
 * [JWChat](https://accounts.jwchat.org/)
 * [jabber.at](https://jabber.at/account/register/)
 * [yax.im](https://yaxim.org/yax.im/)
+* [404.city](https://404.city/)
 
 # 3. Log in! That's it!
 


### PR DESCRIPTION
Add 404.city . One of the forward public servers on Ejabberd. Supports all useful XEPs. The server with open registrations in XMPP-clients.
XEP-0163: PEP avatars and OMEMO
XEP-0191: Blocking Command
XEP-0198: Stream Management
XEP-0237:Roster Versioning
XEP-0280: Message Carbons
XEP-0313: MAM
XEP-0352: Client State Indication
XEP-0357: Push
XEP-0363: HTTP file upload