### PR TITLE
libraries: Fix QXmpp URL

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -351,7 +351,7 @@
         "platforms": [
             "C++"
         ],
-        "url": "www.qxmpp.org"
+        "url": "http://qxmpp.org"
     },
     {
         "last_renewed": null,


### PR DESCRIPTION
The link was dead (or just missing `http://`). Unfortunately they don't
provide https.