### PR TITLE
Replaced defunct tracker for Trademark applications.

### DIFF
--- a/content/pages/about/xsf/jabber-trademark/pending-applications.md
+++ b/content/pages/about/xsf/jabber-trademark/pending-applications.md
@@ -35,4 +35,8 @@ Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
 Content_layout: multiple-columns
 ---
 
-Pending applications are now tracked at [http://tracker.xmpp.org/browse/TRADEMARKS](http://tracker.xmpp.org/browse/TRADEMARKS)
+This page lists pending appliations for a license to make use of the [Jabber trademark](/about/xsf/jabber-trademark).
+
+| Mark                                  | Licensee                    | Type                        |
+|---------------------------------------|-----------------------------|-----------------------------|
+|                                       |                             |                             |


### PR DESCRIPTION
The tracker that is linked to in the old version appears to be gone.