### PR TITLE
Events: Make conferences a list

### DIFF
--- a/content/pages/community/events.md
+++ b/content/pages/community/events.md
@@ -33,8 +33,8 @@ The XSF organizes periodic in-person gatherings in order to coordinate high-band
 
 ## Conferences
 
-[XMPP Summit 23, Brussels, Belgium](https://wiki.xmpp.org/web/Summit_23)
-[FOSDEM 2019, Brussels, Belgium](https://wiki.xmpp.org/web/FOSDEM_2019)
+* [XMPP Summit 23, Brussels, Belgium](https://wiki.xmpp.org/web/Summit_23)
+* [FOSDEM 2019, Brussels, Belgium](https://wiki.xmpp.org/web/FOSDEM_2019)
 
 ## Meetups
 


### PR DESCRIPTION
There was a missing newline between Summit and FOSDEM. I thought a list might be better anyway.

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>