### PR TITLE
Add landing page for Summit 23

### DIFF
--- a/content/pages/community/events.md
+++ b/content/pages/community/events.md
@@ -31,7 +31,7 @@ __See something missing?__ Events come and go at a speed that is sometimes hard 
 
 The XSF organizes periodic in-person gatherings in order to coordinate high-bandwidth conversations, interop testing, brainstorming and planning, and to conduct other XSF business face-to-face.
 
-* [XMPP Summit 23, Brussels, Belgium](/community/events/summit23)
+* [XMPP Summit 23, Brussels, Belgium]({filename}pages/community/events/summit23)
 
 ## Conferences
 

--- a/content/pages/community/events.md
+++ b/content/pages/community/events.md
@@ -31,9 +31,10 @@ __See something missing?__ Events come and go at a speed that is sometimes hard 
 
 The XSF organizes periodic in-person gatherings in order to coordinate high-bandwidth conversations, interop testing, brainstorming and planning, and to conduct other XSF business face-to-face.
 
+* [XMPP Summit 23, Brussels, Belgium](/community/events/summit23)
+
 ## Conferences
 
-* [XMPP Summit 23, Brussels, Belgium](https://wiki.xmpp.org/web/Summit_23)
 * [FOSDEM 2019, Brussels, Belgium](https://wiki.xmpp.org/web/FOSDEM_2019)
 
 ## Meetups
@@ -48,13 +49,12 @@ community, to improve the ecosystem.
 You can find more detailed information about sprints on the [wiki
 page](https://wiki.xmpp.org/web/Sprints).
 
-
-### Upcoming Events
+### Upcoming
 
 * [Brussels, January 30th, 2019](https://wiki.xmpp.org/web/Sprints/2019_January_Brussels) (around FOSDEM)
 * [Berlin, March 30-31st, 2019](https://wiki.xmpp.org/web/Sprints/2019_March_Berlin)
 
-### Past Events
+### Past
 
 * [Dusseldorf, November 17-18th, 2018](https://wiki.xmpp.org/web/Sprints/2018_November_Dusseldorf)
 * [Cambridge, August 18-19th, 2018](https://wiki.xmpp.org/web/Sprints/2018_August_Cambridge)

--- a/content/pages/community/events.md
+++ b/content/pages/community/events.md
@@ -31,7 +31,7 @@ __See something missing?__ Events come and go at a speed that is sometimes hard 
 
 The XSF organizes periodic in-person gatherings in order to coordinate high-bandwidth conversations, interop testing, brainstorming and planning, and to conduct other XSF business face-to-face.
 
-* [XMPP Summit 23, Brussels, Belgium]({filename}pages/community/events/summit23)
+* [XMPP Summit 23, Brussels, Belgium](/community/events/summit23)
 
 ## Conferences
 

--- a/content/pages/community/events/summit23.md
+++ b/content/pages/community/events/summit23.md
@@ -1,0 +1,22 @@
+---
+Title: Summit 23
+Url: community/events/summit23
+Save_as: community/events/summit23.html
+Parent_id: community/events
+Top_menu_show: false
+Top_Menu_order: -1
+Dropdown_menu_show: false
+Footer_show: false
+Sidebar_menu_show: false
+Content_layout: multiple-columns
+---
+
+The 23rd XMPP Summit will happen right before FOSDEM in Brussels, on January 31st and February 1st, 2019!
+
+The XMPP Summit is a yearly event, open to all participants in the standards process, and anyone working on or with XMPP. 
+
+Run as an "Unconference", the agenda is only finalised on the first morning, and is therefore highly fluid. Previous items on the agenda have ranged from low-level discussions on Groupchat to high level discussion on how XMPP is used, and how it can support modern UX needs.
+
+With heavy attendance from many key XEP authors and developers, places are limited, but registration is free. Lunch is often covered by sponsors, and it takes place in Brussels just before the legendary FOSDEM conference.
+
+If you're interested in attending, please review the [summit page on our wiki](https://wiki.xmpp.org/web/Summit_23) that we use for organizing the event!

--- a/content/pages/index.html
+++ b/content/pages/index.html
@@ -13,7 +13,7 @@
 <body>
   <header class="header-home">
     <div class="hero">
-      <a class="summit-banner" style="color: white; font-size: 120%; background: #008CBA; margin-left: -20px; margin-right: -20px; margin-top: -20px; padding: 20px; display: block;" href="https://wiki.xmpp.org/web/Summit_23">
+      <a class="summit-banner" style="color: white; font-size: 120%; background: #008CBA; margin-left: -20px; margin-right: -20px; margin-top: -20px; padding: 20px; display: block;" href="/community/events/summit23">
         The 23rd XMPP Summit will happen right before FOSDEM in Brussels, Jan 31st and Feb 1st, 2019. Click for more info!
       </a>
       <h1>The most secure messaging standard</h1>


### PR DESCRIPTION
Various community members provided feedback, explaining that having a public
landing page for the event would help convince powers-that-be that the event
is indeed a Real Thing. People are more likely to secure permits to travel to
and attend events when they are Real Thing-classified.