### PR TITLE
Side menus

### DIFF
--- a/content/pages/about/faq.md
+++ b/content/pages/about/faq.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About XMPP
-Sidebar_menu_size: 7
-Sidebar_menu_elem_name_1: History
-Sidebar_menu_elem_url_1: about/history
-Sidebar_menu_elem_name_2: Overview
-Sidebar_menu_elem_url_2: about/technology-overview
-Sidebar_menu_elem_name_3: Myths & Legends
-Sidebar_menu_elem_url_3: about/myths
-Sidebar_menu_elem_name_4: Standards Process
-Sidebar_menu_elem_url_4: about/standards-process
-Sidebar_menu_elem_name_5: The XSF
-Sidebar_menu_elem_url_5: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_6: Specifications
-Sidebar_menu_elem_url_6: extensions/index
-Sidebar_menu_elem_name_7: FAQ
-Sidebar_menu_elem_url_7: about/faq
+Inherit_sidebar: about
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/history.md
+++ b/content/pages/about/history.md
@@ -4,7 +4,7 @@ Url: about/history
 Save_as: about/history.html
 Parent_id: about
 Sidebar_menu_show: true
-Inherit_sidebar: true
+Inherit_sidebar: about
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/myths.md
+++ b/content/pages/about/myths.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About XMPP
-Sidebar_menu_size: 7
-Sidebar_menu_elem_name_1: History
-Sidebar_menu_elem_url_1: about/history
-Sidebar_menu_elem_name_2: Overview
-Sidebar_menu_elem_url_2: about/technology-overview
-Sidebar_menu_elem_name_3: Myths & Legends
-Sidebar_menu_elem_url_3: about/myths
-Sidebar_menu_elem_name_4: Standards Process
-Sidebar_menu_elem_url_4: about/standards-process
-Sidebar_menu_elem_name_5: The XSF
-Sidebar_menu_elem_url_5: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_6: Specifications
-Sidebar_menu_elem_url_6: extensions/index
-Sidebar_menu_elem_name_7: FAQ
-Sidebar_menu_elem_url_7: about/faq
+Inherit_sidebar: about
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/standards-process.md
+++ b/content/pages/about/standards-process.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About XMPP
-Sidebar_menu_size: 7
-Sidebar_menu_elem_name_1: History
-Sidebar_menu_elem_url_1: about/history
-Sidebar_menu_elem_name_2: Overview
-Sidebar_menu_elem_url_2: about/technology-overview
-Sidebar_menu_elem_name_3: Myths & Legends
-Sidebar_menu_elem_url_3: about/myths
-Sidebar_menu_elem_name_4: Standards Process
-Sidebar_menu_elem_url_4: about/standards-process
-Sidebar_menu_elem_name_5: The XSF
-Sidebar_menu_elem_url_5: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_6: Specifications
-Sidebar_menu_elem_url_6: extensions/index
-Sidebar_menu_elem_name_7: FAQ
-Sidebar_menu_elem_url_7: about/faq
+Inherit_sidebar: about
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/technology-overview.md
+++ b/content/pages/about/technology-overview.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About XMPP
-Sidebar_menu_size: 7
-Sidebar_menu_elem_name_1: History
-Sidebar_menu_elem_url_1: about/history
-Sidebar_menu_elem_name_2: Overview
-Sidebar_menu_elem_url_2: about/technology-overview
-Sidebar_menu_elem_name_3: Myths & Legends
-Sidebar_menu_elem_url_3: about/myths
-Sidebar_menu_elem_name_4: Standards Process
-Sidebar_menu_elem_url_4: about/standards-process
-Sidebar_menu_elem_name_5: The XSF
-Sidebar_menu_elem_url_5: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_6: Specifications
-Sidebar_menu_elem_url_6: ../extensions/
-Sidebar_menu_elem_name_7: FAQ
-Sidebar_menu_elem_url_7: about/faq
+Inherit_sidebar: about
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/the-jabber-project.md
+++ b/content/pages/about/the-jabber-project.md
@@ -4,7 +4,7 @@ Url: about/the-jabber-project
 Save_as: about/the-jabber-project.html
 Parent_id: about
 Sidebar_menu_show: true
-Inherit_sidebar: true
+Inherit_sidebar: about
 Content_layout: multiple-columns
 ---
 _Note: This is the original statement provided by Jeremie Miller, inventor of Jabber/XMPP technologies, regarding the early Jabber project’s involvement with and support for the IETF’s standardization efforts with respect to instant messaging and presence._

--- a/content/pages/about/xmpp-standards-foundation.md
+++ b/content/pages/about/xmpp-standards-foundation.md
@@ -5,7 +5,7 @@ Save_as: about/xmpp-standards-foundation.html
 Parent_id: about
 Sidebar_menu_show: true
 Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 7
+Sidebar_menu_size: 6
 Sidebar_menu_elem_name_1: The XSF
 Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
 Sidebar_menu_elem_name_2: Members
@@ -18,8 +18,6 @@ Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
 Sidebar_menu_elem_url_5: about/xsf/scam-team
 Sidebar_menu_elem_name_6: Communication Team
 Sidebar_menu_elem_url_6: about/xsf/comm-team
-Sidebar_menu_elem_name_7: Standards Process
-Sidebar_menu_elem_url_7: about/standards-process
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xmpp-standards-foundation.md
+++ b/content/pages/about/xmpp-standards-foundation.md
@@ -4,7 +4,22 @@ Url: about/xmpp-standards-foundation
 Save_as: about/xmpp-standards-foundation.html
 Parent_id: about
 Sidebar_menu_show: true
-Inherit_sidebar: true
+Sidebar_menu_title: About the XSF
+Sidebar_menu_size: 7
+Sidebar_menu_elem_name_1: The XSF
+Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
+Sidebar_menu_elem_name_2: Members
+Sidebar_menu_elem_url_2: about/xsf/members
+Sidebar_menu_elem_name_3: Editor Team
+Sidebar_menu_elem_url_3: about/xsf/editor-team
+Sidebar_menu_elem_name_4: Infrastructure Team
+Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
+Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
+Sidebar_menu_elem_url_5: about/xsf/scam-team
+Sidebar_menu_elem_name_6: Communication Team
+Sidebar_menu_elem_url_6: about/xsf/comm-team
+Sidebar_menu_elem_name_7: Standards Process
+Sidebar_menu_elem_url_7: about/standards-process
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/bylaws.md
+++ b/content/pages/about/xsf/bylaws.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/communication-team.md
+++ b/content/pages/about/xsf/communication-team.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Communication Team
-Sidebar_menu_elem_url_6: about/xsf/comm-team
-Sidebar_menu_elem_name_7: Standards Process
-Sidebar_menu_elem_url_7: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 Template: team_page
 Team_Role: commteam

--- a/content/pages/about/xsf/communications-policy.md
+++ b/content/pages/about/xsf/communications-policy.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Communication Team
-Sidebar_menu_elem_url_6: about/xsf/comm-team
-Sidebar_menu_elem_name_7: Standards Process
-Sidebar_menu_elem_url_7: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/council-policies-and-procedures.md
+++ b/content/pages/about/xsf/council-policies-and-procedures.md
@@ -4,7 +4,7 @@ Url: about/xsf/council-policies-and-procedures
 Save_as: about/xsf/council-policies-and-procedures.html
 Parent_id: about
 Sidebar_menu_show: true
-Inherit_sidebar: true
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/editor-team.md
+++ b/content/pages/about/xsf/editor-team.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Communication Team
-Sidebar_menu_elem_url_6: about/xsf/comm-team
-Sidebar_menu_elem_name_7: Standards Process
-Sidebar_menu_elem_url_7: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 Template: team_page
 Team_Role: editor

--- a/content/pages/about/xsf/infrastructure-team.md
+++ b/content/pages/about/xsf/infrastructure-team.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Communication Team
-Sidebar_menu_elem_url_6: about/xsf/comm-team
-Sidebar_menu_elem_name_7: Standards Process
-Sidebar_menu_elem_url_7: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 Template: team_page
 Team_Role: infrastructure

--- a/content/pages/about/xsf/ipr-policy.md
+++ b/content/pages/about/xsf/ipr-policy.md
@@ -4,6 +4,7 @@ Url: about/xsf/ipr-policy
 Save_as: about/xsf/ipr-policy.html
 Parent_id: about
 Sidebar_menu_show: true
+Inherit_sidebar: about/xmpp-standards-foundation
 ---
 This document defines the official policy of the XMPP Standards Foundation regarding intellectual property rights (IPR) pertaining to XMPP Extension Protocol specifications (XEPs).
 

--- a/content/pages/about/xsf/jabber-trademark/approved-applications.md
+++ b/content/pages/about/xsf/jabber-trademark/approved-applications.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/background.md
+++ b/content/pages/about/xsf/jabber-trademark/background.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/dispute-resolution.md
+++ b/content/pages/about/xsf/jabber-trademark/dispute-resolution.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/how-the-license-works.md
+++ b/content/pages/about/xsf/jabber-trademark/how-the-license-works.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/license-decision-process.md
+++ b/content/pages/about/xsf/jabber-trademark/license-decision-process.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/license-terms.md
+++ b/content/pages/about/xsf/jabber-trademark/license-terms.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/pending-applications.md
+++ b/content/pages/about/xsf/jabber-trademark/pending-applications.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/trademark-license-agreement.md
+++ b/content/pages/about/xsf/jabber-trademark/trademark-license-agreement.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/unlicensed-users.md
+++ b/content/pages/about/xsf/jabber-trademark/unlicensed-users.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/usage-guidelines.md
+++ b/content/pages/about/xsf/jabber-trademark/usage-guidelines.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/whats-required.md
+++ b/content/pages/about/xsf/jabber-trademark/whats-required.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/jabber-trademark/who-needs-a-license.md
+++ b/content/pages/about/xsf/jabber-trademark/who-needs-a-license.md
@@ -8,30 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Jabber Trademark
-Sidebar_menu_size: 11
-Sidebar_menu_elem_name_1: Licensing program
-Sidebar_menu_elem_url_1: about/xsf/jabber-trademark
-Sidebar_menu_elem_name_2: Background
-Sidebar_menu_elem_url_2: about/xsf/jabber-trademark/background
-Sidebar_menu_elem_name_3: Usage guidelines
-Sidebar_menu_elem_url_3: about/xsf/jabber-trademark/usage-guidelines
-Sidebar_menu_elem_name_4: Who needs a license
-Sidebar_menu_elem_url_4: about/xsf/jabber-trademark/who-needs-a-license
-Sidebar_menu_elem_name_5: What's required
-Sidebar_menu_elem_url_5: about/xsf/jabber-trademark/whats-required
-Sidebar_menu_elem_name_6: Unlicensed users
-Sidebar_menu_elem_url_6: about/xsf/jabber-trademark/unlicensed-users
-Sidebar_menu_elem_name_7: Licensing decision process & application
-Sidebar_menu_elem_url_7: about/xsf/jabber-trademark/license-decision-process
-Sidebar_menu_elem_name_8: Dispute resolution
-Sidebar_menu_elem_url_8: about/xsf/jabber-trademark/dispute-resolution
-Sidebar_menu_elem_name_9: Trademark license agreement
-Sidebar_menu_elem_url_9: about/xsf/jabber-trademark/trademark-license-agreement
-Sidebar_menu_elem_name_10: Pending applications
-Sidebar_menu_elem_url_10: about/xsf/jabber-trademark/pending-applications
-Sidebar_menu_elem_name_11: Approved applications
-Sidebar_menu_elem_url_11: about/xsf/jabber-trademark/approved-applications
+Inherit_sidebar: about/xsf/jabber-trademark
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/members.md
+++ b/content/pages/about/xsf/members.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 Template: member_list
 ---

--- a/content/pages/about/xsf/mission.md
+++ b/content/pages/about/xsf/mission.md
@@ -4,7 +4,7 @@ Url: about/xsf/mission
 Save_as: about/xsf/mission.html
 Parent_id: about
 Sidebar_menu_show: true
-Inherit_sidebar: true
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/organizational-documents.md
+++ b/content/pages/about/xsf/organizational-documents.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/people.md
+++ b/content/pages/about/xsf/people.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Communication Team
-Sidebar_menu_elem_url_6: about/xsf/comm-team
-Sidebar_menu_elem_name_7: Standards Process
-Sidebar_menu_elem_url_7: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/records/_index.md
+++ b/content/pages/about/xsf/records/_index.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: UPnP Liaison Team
-Sidebar_menu_elem_url_5: about/xsf/upnp-liaison-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/records/council-votes/tallies_01.md
+++ b/content/pages/about/xsf/records/council-votes/tallies_01.md
@@ -3,26 +3,7 @@ Url: about/xsf/records/council-votes/tallies_2001-2002
 Save_as: about/xsf/records/council-votes/tallies_2001-2002.html
 Parent_id: about/xsf/records/council-votes
 Sidebar_menu_show: true
-Sidebar_menu_title: Voting history
-Sidebar_menu_size: 9
-Sidebar_menu_elem_name_1: 2001-2002
-Sidebar_menu_elem_url_1: about/xsf/records/council-votes/tallies_2001-2002
-Sidebar_menu_elem_name_2: 2002-2003
-Sidebar_menu_elem_url_2: about/xsf/records/council-votes/tallies_2002-2003
-Sidebar_menu_elem_name_3: 2003-2004
-Sidebar_menu_elem_url_3: about/xsf/records/council-votes/tallies_2003-2004
-Sidebar_menu_elem_name_4: 2004-2005
-Sidebar_menu_elem_url_4: about/xsf/records/council-votes/tallies_2004-2005
-Sidebar_menu_elem_name_5: 2005-2006
-Sidebar_menu_elem_url_5: about/xsf/records/council-votes/tallies_2005-2006
-Sidebar_menu_elem_name_6: 2006-2007
-Sidebar_menu_elem_url_6: about/xsf/records/council-votes/tallies_2006-2007
-Sidebar_menu_elem_name_7: 2007-2008
-Sidebar_menu_elem_url_7: about/xsf/records/council-votes/tallies_2007-2008
-Sidebar_menu_elem_name_8: 2008-2009
-Sidebar_menu_elem_url_8: about/xsf/records/council-votes/tallies_2008-2009
-Sidebar_menu_elem_name_9: 2009-2010
-Sidebar_menu_elem_url_9: about/xsf/records/council-votes/tallies_2009-2010
+Inherit_sidebar: about/xsf/records/council-votes
 Content_layout: multiple-columns
 
 This page provides detailed voting status information for each [XMPP Extension Protocol] that was presented to the First [XMPP Council] in 2001-2002. For further information, refer to the [mailing list archives] or contact the [XMPP Extensions Editor].

--- a/content/pages/about/xsf/records/council-votes/tallies_02.md
+++ b/content/pages/about/xsf/records/council-votes/tallies_02.md
@@ -3,26 +3,7 @@ Url: about/xsf/records/council-votes/tallies_2002-2003
 Save_as: about/xsf/records/council-votes/tallies_2002-2003.html
 Parent_id: about/xsf/records/council-votes
 Sidebar_menu_show: true
-Sidebar_menu_title: Voting history
-Sidebar_menu_size: 9
-Sidebar_menu_elem_name_1: 2001-2002
-Sidebar_menu_elem_url_1: about/xsf/records/council-votes/tallies_2001-2002
-Sidebar_menu_elem_name_2: 2002-2003
-Sidebar_menu_elem_url_2: about/xsf/records/council-votes/tallies_2002-2003
-Sidebar_menu_elem_name_3: 2003-2004
-Sidebar_menu_elem_url_3: about/xsf/records/council-votes/tallies_2003-2004
-Sidebar_menu_elem_name_4: 2004-2005
-Sidebar_menu_elem_url_4: about/xsf/records/council-votes/tallies_2004-2005
-Sidebar_menu_elem_name_5: 2005-2006
-Sidebar_menu_elem_url_5: about/xsf/records/council-votes/tallies_2005-2006
-Sidebar_menu_elem_name_6: 2006-2007
-Sidebar_menu_elem_url_6: about/xsf/records/council-votes/tallies_2006-2007
-Sidebar_menu_elem_name_7: 2007-2008
-Sidebar_menu_elem_url_7: about/xsf/records/council-votes/tallies_2007-2008
-Sidebar_menu_elem_name_8: 2008-2009
-Sidebar_menu_elem_url_8: about/xsf/records/council-votes/tallies_2008-2009
-Sidebar_menu_elem_name_9: 2009-2010
-Sidebar_menu_elem_url_9: about/xsf/records/council-votes/tallies_2009-2010
+Inherit_sidebar: about/xsf/records/council-votes
 Content_layout: multiple-columns
 
 This page provides detailed voting status information for each [XMPP Extension Protocol] that was presented to the Second [XMPP Council] in 2002-2003. For further information, refer to the [mailing list archives] or contact the [XMPP Extensions Editor].

--- a/content/pages/about/xsf/records/council-votes/tallies_03.md
+++ b/content/pages/about/xsf/records/council-votes/tallies_03.md
@@ -3,26 +3,7 @@ Url: about/xsf/records/council-votes/tallies_2003-2004
 Save_as: about/xsf/records/council-votes/tallies_2003-2004.html
 Parent_id: about/xsf/records/council-votes
 Sidebar_menu_show: true
-Sidebar_menu_title: Voting history
-Sidebar_menu_size: 9
-Sidebar_menu_elem_name_1: 2001-2002
-Sidebar_menu_elem_url_1: about/xsf/records/council-votes/tallies_2001-2002
-Sidebar_menu_elem_name_2: 2002-2003
-Sidebar_menu_elem_url_2: about/xsf/records/council-votes/tallies_2002-2003
-Sidebar_menu_elem_name_3: 2003-2004
-Sidebar_menu_elem_url_3: about/xsf/records/council-votes/tallies_2003-2004
-Sidebar_menu_elem_name_4: 2004-2005
-Sidebar_menu_elem_url_4: about/xsf/records/council-votes/tallies_2004-2005
-Sidebar_menu_elem_name_5: 2005-2006
-Sidebar_menu_elem_url_5: about/xsf/records/council-votes/tallies_2005-2006
-Sidebar_menu_elem_name_6: 2006-2007
-Sidebar_menu_elem_url_6: about/xsf/records/council-votes/tallies_2006-2007
-Sidebar_menu_elem_name_7: 2007-2008
-Sidebar_menu_elem_url_7: about/xsf/records/council-votes/tallies_2007-2008
-Sidebar_menu_elem_name_8: 2008-2009
-Sidebar_menu_elem_url_8: about/xsf/records/council-votes/tallies_2008-2009
-Sidebar_menu_elem_name_9: 2009-2010
-Sidebar_menu_elem_url_9: about/xsf/records/council-votes/tallies_2009-2010
+Inherit_sidebar: about/xsf/records/council-votes
 Content_layout: multiple-columns
 
 This page provides detailed voting status information for each [XMPP Extension Protocol] proposed to the Third [XMPP Council](2003-2004). For further information, refer to the [mailing list archives] or contact the [XMPP Extensions Editor].

--- a/content/pages/about/xsf/records/council-votes/tallies_04.md
+++ b/content/pages/about/xsf/records/council-votes/tallies_04.md
@@ -3,26 +3,7 @@ Url: about/xsf/records/council-votes/tallies_2004-2005
 Save_as: about/xsf/records/council-votes/tallies_2004-2005.html
 Parent_id: about/xsf/records/council-votes
 Sidebar_menu_show: true
-Sidebar_menu_title: Voting history
-Sidebar_menu_size: 9
-Sidebar_menu_elem_name_1: 2001-2002
-Sidebar_menu_elem_url_1: about/xsf/records/council-votes/tallies_2001-2002
-Sidebar_menu_elem_name_2: 2002-2003
-Sidebar_menu_elem_url_2: about/xsf/records/council-votes/tallies_2002-2003
-Sidebar_menu_elem_name_3: 2003-2004
-Sidebar_menu_elem_url_3: about/xsf/records/council-votes/tallies_2003-2004
-Sidebar_menu_elem_name_4: 2004-2005
-Sidebar_menu_elem_url_4: about/xsf/records/council-votes/tallies_2004-2005
-Sidebar_menu_elem_name_5: 2005-2006
-Sidebar_menu_elem_url_5: about/xsf/records/council-votes/tallies_2005-2006
-Sidebar_menu_elem_name_6: 2006-2007
-Sidebar_menu_elem_url_6: about/xsf/records/council-votes/tallies_2006-2007
-Sidebar_menu_elem_name_7: 2007-2008
-Sidebar_menu_elem_url_7: about/xsf/records/council-votes/tallies_2007-2008
-Sidebar_menu_elem_name_8: 2008-2009
-Sidebar_menu_elem_url_8: about/xsf/records/council-votes/tallies_2008-2009
-Sidebar_menu_elem_name_9: 2009-2010
-Sidebar_menu_elem_url_9: about/xsf/records/council-votes/tallies_2009-2010
+Inherit_sidebar: about/xsf/records/council-votes
 Content_layout: multiple-columns
 
 This page provides detailed voting status information for each [XMPP Extension Protocols] proposed to the Fourth [XMPP Council](2004-2005). For further information, refer to the [mailing list archives] and [chatroom logs], or contact the [XMPP Extensions Editor].

--- a/content/pages/about/xsf/records/council-votes/tallies_05.md
+++ b/content/pages/about/xsf/records/council-votes/tallies_05.md
@@ -3,26 +3,7 @@ Url: about/xsf/records/council-votes/tallies_2005-2006
 Save_as: about/xsf/records/council-votes/tallies_2005-2006.html
 Parent_id: about/xsf/records/council-votes
 Sidebar_menu_show: true
-Sidebar_menu_title: Voting history
-Sidebar_menu_size: 9
-Sidebar_menu_elem_name_1: 2001-2002
-Sidebar_menu_elem_url_1: about/xsf/records/council-votes/tallies_2001-2002
-Sidebar_menu_elem_name_2: 2002-2003
-Sidebar_menu_elem_url_2: about/xsf/records/council-votes/tallies_2002-2003
-Sidebar_menu_elem_name_3: 2003-2004
-Sidebar_menu_elem_url_3: about/xsf/records/council-votes/tallies_2003-2004
-Sidebar_menu_elem_name_4: 2004-2005
-Sidebar_menu_elem_url_4: about/xsf/records/council-votes/tallies_2004-2005
-Sidebar_menu_elem_name_5: 2005-2006
-Sidebar_menu_elem_url_5: about/xsf/records/council-votes/tallies_2005-2006
-Sidebar_menu_elem_name_6: 2006-2007
-Sidebar_menu_elem_url_6: about/xsf/records/council-votes/tallies_2006-2007
-Sidebar_menu_elem_name_7: 2007-2008
-Sidebar_menu_elem_url_7: about/xsf/records/council-votes/tallies_2007-2008
-Sidebar_menu_elem_name_8: 2008-2009
-Sidebar_menu_elem_url_8: about/xsf/records/council-votes/tallies_2008-2009
-Sidebar_menu_elem_name_9: 2009-2010
-Sidebar_menu_elem_url_9: about/xsf/records/council-votes/tallies_2009-2010
+Inherit_sidebar: about/xsf/records/council-votes
 Content_layout: multiple-columns
 
 This page provides detailed voting status information for each [XMPP Extension Protocol] proposed to the Fifth [XMPP Council](2005-2006). For further information, refer to the [mailing list archives] and [chatroom logs], or contact the [XMPP Extensions Editor].

--- a/content/pages/about/xsf/records/council-votes/tallies_06.md
+++ b/content/pages/about/xsf/records/council-votes/tallies_06.md
@@ -3,26 +3,7 @@ Url: about/xsf/records/council-votes/tallies_2006-2007
 Save_as: about/xsf/records/council-votes/tallies_2006-2007.html
 Parent_id: about/xsf/records/council-votes
 Sidebar_menu_show: true
-Sidebar_menu_title: Voting history
-Sidebar_menu_size: 9
-Sidebar_menu_elem_name_1: 2001-2002
-Sidebar_menu_elem_url_1: about/xsf/records/council-votes/tallies_2001-2002
-Sidebar_menu_elem_name_2: 2002-2003
-Sidebar_menu_elem_url_2: about/xsf/records/council-votes/tallies_2002-2003
-Sidebar_menu_elem_name_3: 2003-2004
-Sidebar_menu_elem_url_3: about/xsf/records/council-votes/tallies_2003-2004
-Sidebar_menu_elem_name_4: 2004-2005
-Sidebar_menu_elem_url_4: about/xsf/records/council-votes/tallies_2004-2005
-Sidebar_menu_elem_name_5: 2005-2006
-Sidebar_menu_elem_url_5: about/xsf/records/council-votes/tallies_2005-2006
-Sidebar_menu_elem_name_6: 2006-2007
-Sidebar_menu_elem_url_6: about/xsf/records/council-votes/tallies_2006-2007
-Sidebar_menu_elem_name_7: 2007-2008
-Sidebar_menu_elem_url_7: about/xsf/records/council-votes/tallies_2007-2008
-Sidebar_menu_elem_name_8: 2008-2009
-Sidebar_menu_elem_url_8: about/xsf/records/council-votes/tallies_2008-2009
-Sidebar_menu_elem_name_9: 2009-2010
-Sidebar_menu_elem_url_9: about/xsf/records/council-votes/tallies_2009-2010
+Inherit_sidebar: about/xsf/records/council-votes
 Content_layout: multiple-columns
 
 This page provides detailed voting status information for each [XMPP Extension Protocol] proposed to the Sixth [XMPP Council](2006-2007). For further information, refer to the [mailing list archives] and [chatroom logs], or contact the [XMPP Extensions Editor].

--- a/content/pages/about/xsf/records/council-votes/tallies_07.md
+++ b/content/pages/about/xsf/records/council-votes/tallies_07.md
@@ -3,26 +3,7 @@ Url: about/xsf/records/council-votes/tallies_2007-2008
 Save_as: about/xsf/records/council-votes/tallies_2007-2008.html
 Parent_id: about/xsf/records/council-votes
 Sidebar_menu_show: true
-Sidebar_menu_title: Voting history
-Sidebar_menu_size: 9
-Sidebar_menu_elem_name_1: 2001-2002
-Sidebar_menu_elem_url_1: about/xsf/records/council-votes/tallies_2001-2002
-Sidebar_menu_elem_name_2: 2002-2003
-Sidebar_menu_elem_url_2: about/xsf/records/council-votes/tallies_2002-2003
-Sidebar_menu_elem_name_3: 2003-2004
-Sidebar_menu_elem_url_3: about/xsf/records/council-votes/tallies_2003-2004
-Sidebar_menu_elem_name_4: 2004-2005
-Sidebar_menu_elem_url_4: about/xsf/records/council-votes/tallies_2004-2005
-Sidebar_menu_elem_name_5: 2005-2006
-Sidebar_menu_elem_url_5: about/xsf/records/council-votes/tallies_2005-2006
-Sidebar_menu_elem_name_6: 2006-2007
-Sidebar_menu_elem_url_6: about/xsf/records/council-votes/tallies_2006-2007
-Sidebar_menu_elem_name_7: 2007-2008
-Sidebar_menu_elem_url_7: about/xsf/records/council-votes/tallies_2007-2008
-Sidebar_menu_elem_name_8: 2008-2009
-Sidebar_menu_elem_url_8: about/xsf/records/council-votes/tallies_2008-2009
-Sidebar_menu_elem_name_9: 2009-2010
-Sidebar_menu_elem_url_9: about/xsf/records/council-votes/tallies_2009-2010
+Inherit_sidebar: about/xsf/records/council-votes
 Content_layout: multiple-columns
 
 This page provides detailed voting status information for each [XMPP Extension Protocol] proposed to the Seventh [XMPP Council](2007-2008). For further information, refer to the [mailing list archives] and [chatroom logs], or contact the [XMPP Extensions Editor].

--- a/content/pages/about/xsf/records/council-votes/tallies_08.md
+++ b/content/pages/about/xsf/records/council-votes/tallies_08.md
@@ -3,26 +3,7 @@ Url: about/xsf/records/council-votes/tallies_2008-2009
 Save_as: about/xsf/records/council-votes/tallies_2008-2009.html
 Parent_id: about/xsf/records/council-votes
 Sidebar_menu_show: true
-Sidebar_menu_title: Voting history
-Sidebar_menu_size: 9
-Sidebar_menu_elem_name_1: 2001-2002
-Sidebar_menu_elem_url_1: about/xsf/records/council-votes/tallies_2001-2002
-Sidebar_menu_elem_name_2: 2002-2003
-Sidebar_menu_elem_url_2: about/xsf/records/council-votes/tallies_2002-2003
-Sidebar_menu_elem_name_3: 2003-2004
-Sidebar_menu_elem_url_3: about/xsf/records/council-votes/tallies_2003-2004
-Sidebar_menu_elem_name_4: 2004-2005
-Sidebar_menu_elem_url_4: about/xsf/records/council-votes/tallies_2004-2005
-Sidebar_menu_elem_name_5: 2005-2006
-Sidebar_menu_elem_url_5: about/xsf/records/council-votes/tallies_2005-2006
-Sidebar_menu_elem_name_6: 2006-2007
-Sidebar_menu_elem_url_6: about/xsf/records/council-votes/tallies_2006-2007
-Sidebar_menu_elem_name_7: 2007-2008
-Sidebar_menu_elem_url_7: about/xsf/records/council-votes/tallies_2007-2008
-Sidebar_menu_elem_name_8: 2008-2009
-Sidebar_menu_elem_url_8: about/xsf/records/council-votes/tallies_2008-2009
-Sidebar_menu_elem_name_9: 2009-2010
-Sidebar_menu_elem_url_9: about/xsf/records/council-votes/tallies_2009-2010
+Inherit_sidebar: about/xsf/records/council-votes
 Content_layout: multiple-columns
 
 This page provides detailed voting status information for each [XMPP Extension Protocol] proposed to the Eighth [XMPP Council](2008-2009). For further information, refer to the [mailing list archives] and [chatroom logs], or contact the [XMPP Extensions Editor].

--- a/content/pages/about/xsf/records/council-votes/tallies_09.md
+++ b/content/pages/about/xsf/records/council-votes/tallies_09.md
@@ -3,26 +3,7 @@ Url: about/xsf/records/council-votes/tallies_2009-2010
 Save_as: about/xsf/records/council-votes/tallies_2009-2010.html
 Parent_id: about/xsf/records/council-votes
 Sidebar_menu_show: true
-Sidebar_menu_title: Voting history
-Sidebar_menu_size: 9
-Sidebar_menu_elem_name_1: 2001-2002
-Sidebar_menu_elem_url_1: about/xsf/records/council-votes/tallies_2001-2002
-Sidebar_menu_elem_name_2: 2002-2003
-Sidebar_menu_elem_url_2: about/xsf/records/council-votes/tallies_2002-2003
-Sidebar_menu_elem_name_3: 2003-2004
-Sidebar_menu_elem_url_3: about/xsf/records/council-votes/tallies_2003-2004
-Sidebar_menu_elem_name_4: 2004-2005
-Sidebar_menu_elem_url_4: about/xsf/records/council-votes/tallies_2004-2005
-Sidebar_menu_elem_name_5: 2005-2006
-Sidebar_menu_elem_url_5: about/xsf/records/council-votes/tallies_2005-2006
-Sidebar_menu_elem_name_6: 2006-2007
-Sidebar_menu_elem_url_6: about/xsf/records/council-votes/tallies_2006-2007
-Sidebar_menu_elem_name_7: 2007-2008
-Sidebar_menu_elem_url_7: about/xsf/records/council-votes/tallies_2007-2008
-Sidebar_menu_elem_name_8: 2008-2009
-Sidebar_menu_elem_url_8: about/xsf/records/council-votes/tallies_2008-2009
-Sidebar_menu_elem_name_9: 2009-2010
-Sidebar_menu_elem_url_9: about/xsf/records/council-votes/tallies_2009-2010
+Inherit_sidebar: about/xsf/records/council-votes
 Content_layout: multiple-columns
 
 This page provides detailed voting status information for each [XMPP Extension Protocol] proposed to the Ninth [XMPP Council](2009-2010). For further information, refer to the [mailing list archives] and [chatroom logs], or contact the [XMPP Extensions Editor].

--- a/content/pages/about/xsf/records/proposals/clarifying-the-purposes-of-the-xsf.md
+++ b/content/pages/about/xsf/records/proposals/clarifying-the-purposes-of-the-xsf.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: UPnP Liaison Team
-Sidebar_menu_elem_url_5: about/xsf/upnp-liaison-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xsf/records/proposals
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/records/proposals/intermediate-certificate-authority.md
+++ b/content/pages/about/xsf/records/proposals/intermediate-certificate-authority.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: UPnP Liaison Team
-Sidebar_menu_elem_url_5: about/xsf/upnp-liaison-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xsf/records/proposals
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/records/proposals/protocol-branding.md
+++ b/content/pages/about/xsf/records/proposals/protocol-branding.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: UPnP Liaison Team
-Sidebar_menu_elem_url_5: about/xsf/upnp-liaison-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xsf/records/proposals
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/records/proposals/strengthening-trust-in-jabber-technologies.md
+++ b/content/pages/about/xsf/records/proposals/strengthening-trust-in-jabber-technologies.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: UPnP Liaison Team
-Sidebar_menu_elem_url_5: about/xsf/upnp-liaison-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xsf/records/proposals
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/records/proposals/xmpp-standards-foundation.md
+++ b/content/pages/about/xsf/records/proposals/xmpp-standards-foundation.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: UPnP Liaison Team
-Sidebar_menu_elem_url_5: about/xsf/upnp-liaison-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xsf/records/proposals
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/roadmap.md
+++ b/content/pages/about/xsf/roadmap.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Standards Process
-Sidebar_menu_elem_url_6: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/scam-team.md
+++ b/content/pages/about/xsf/scam-team.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Communication Team
-Sidebar_menu_elem_url_6: about/xsf/comm-team
-Sidebar_menu_elem_name_7: Standards Process
-Sidebar_menu_elem_url_7: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 Template: team_page
 Team_Role: scam

--- a/content/pages/about/xsf/source-control.md
+++ b/content/pages/about/xsf/source-control.md
@@ -8,23 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Communication Team
-Sidebar_menu_elem_url_6: about/xsf/comm-team
-Sidebar_menu_elem_name_7: Standards Process
-Sidebar_menu_elem_url_7: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/about/xsf/voting-procedure.md
+++ b/content/pages/about/xsf/voting-procedure.md
@@ -8,22 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: About the XSF
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: The XSF
-Sidebar_menu_elem_url_1: about/xmpp-standards-foundation
-Sidebar_menu_elem_name_2: Members
-Sidebar_menu_elem_url_2: about/xsf/members
-Sidebar_menu_elem_name_3: Editor Team
-Sidebar_menu_elem_url_3: about/xsf/editor-team
-Sidebar_menu_elem_name_4: Infrastructure Team
-Sidebar_menu_elem_url_4: about/xsf/infrastructure-team
-Sidebar_menu_elem_name_5: Summits, Conferences & Meetups Team
-Sidebar_menu_elem_url_5: about/xsf/scam-team
-Sidebar_menu_elem_name_6: Communication Team
-Sidebar_menu_elem_url_6: about/xsf/comm-team
-Sidebar_menu_elem_name_7: Standards Process
-Sidebar_menu_elem_url_7: about/standards-process
+Inherit_sidebar: about/xmpp-standards-foundation
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/community/_index.md
+++ b/content/pages/community/_index.md
@@ -25,7 +25,7 @@ Footer_show: left
 Footer_order: 5
 Sidebar_menu_show: true
 Sidebar_menu_title: Community
-Sidebar_menu_size: 6
+Sidebar_menu_size: 7
 Sidebar_menu_elem_name_1: Chat / logs
 Sidebar_menu_elem_url_1: community/chat
 Sidebar_menu_elem_name_2: Mailing lists

--- a/content/pages/community/chat.md
+++ b/content/pages/community/chat.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Community
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: Chat / logs
-Sidebar_menu_elem_url_1: community/chat
-Sidebar_menu_elem_name_2: Mailing lists
-Sidebar_menu_elem_url_2: community/mailing-lists
-Sidebar_menu_elem_name_3: Membership
-Sidebar_menu_elem_url_3: community/membership
-Sidebar_menu_elem_name_4: Events
-Sidebar_menu_elem_url_4: community/events
-Sidebar_menu_elem_name_5: Sponsors
-Sidebar_menu_elem_url_5: community/sponsors
-Sidebar_menu_elem_name_6: Sponsorship
-Sidebar_menu_elem_url_6: community/sponsorship
+Inherit_sidebar: community
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/community/events.md
+++ b/content/pages/community/events.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Community
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: Chat / logs
-Sidebar_menu_elem_url_1: community/chat
-Sidebar_menu_elem_name_2: Mailing lists
-Sidebar_menu_elem_url_2: community/mailing-lists
-Sidebar_menu_elem_name_3: Membership
-Sidebar_menu_elem_url_3: community/membership
-Sidebar_menu_elem_name_4: Events
-Sidebar_menu_elem_url_4: community/events
-Sidebar_menu_elem_name_5: Sponsors
-Sidebar_menu_elem_url_5: community/sponsors
-Sidebar_menu_elem_name_6: Sponsorship
-Sidebar_menu_elem_url_6: community/sponsorship
+Inherit_sidebar: community
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/community/mailing-lists.md
+++ b/content/pages/community/mailing-lists.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Community
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: Chat / logs
-Sidebar_menu_elem_url_1: community/chat
-Sidebar_menu_elem_name_2: Mailing lists
-Sidebar_menu_elem_url_2: community/mailing-lists
-Sidebar_menu_elem_name_3: Membership
-Sidebar_menu_elem_url_3: community/membership
-Sidebar_menu_elem_name_4: Events
-Sidebar_menu_elem_url_4: community/events
-Sidebar_menu_elem_name_5: Sponsors
-Sidebar_menu_elem_url_5: community/sponsors
-Sidebar_menu_elem_name_6: Sponsorship
-Sidebar_menu_elem_url_6: community/sponsorship
+Inherit_sidebar: community
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/community/membership.md
+++ b/content/pages/community/membership.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Community
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: Chat / logs
-Sidebar_menu_elem_url_1: community/chat
-Sidebar_menu_elem_name_2: Mailing lists
-Sidebar_menu_elem_url_2: community/mailing-lists
-Sidebar_menu_elem_name_3: Membership
-Sidebar_menu_elem_url_3: community/membership
-Sidebar_menu_elem_name_4: Events
-Sidebar_menu_elem_url_4: community/events
-Sidebar_menu_elem_name_5: Sponsors
-Sidebar_menu_elem_url_5: community/sponsors
-Sidebar_menu_elem_name_6: Sponsorship
-Sidebar_menu_elem_url_6: community/sponsorship
+Inherit_sidebar: community
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/community/security-notices/_index.md
+++ b/content/pages/community/security-notices/_index.md
@@ -2,10 +2,10 @@
 Title: Security Notices
 Url: community/security-notices
 Save_as: community/security-notices/index.html
-Parent_id: community/
-Content_layout: multiple-columns
-Inherit_sidebar: true
+Parent_id: community
 Sidebar_menu_show: true
+Inherit_sidebar: community
+Content_layout: multiple-columns
 ---
 
 We have posted one security notice about XMPP protocols and implementations:

--- a/content/pages/community/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas.md
+++ b/content/pages/community/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas.md
@@ -2,10 +2,10 @@
 Title: Uncontrolled Resource Consumption with Highly Compressed XMPP Stanzas
 Url: community/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas
 Save_as: community/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas.html
-Parent_id: community/security-notices/
-Content_layout: multiple-columns
-Inherit_sidebar: true
+Parent_id: community/security-notices
 Sidebar_menu_show: true
+Inherit_sidebar: community
+Content_layout: multiple-columns
 ---
 
 _Original Release Date: 2014-04-04_

--- a/content/pages/community/security-notices/vulnerability-in-xmpp-server-dialback-implementations.md
+++ b/content/pages/community/security-notices/vulnerability-in-xmpp-server-dialback-implementations.md
@@ -2,14 +2,14 @@
 Title: Vulnerability in XMPP Server Dialback Implementations
 Url: community/security-notices/vulnerability-in-xmpp-server-dialback-implementations
 Save_as: community/security-notices/vulnerability-in-xmpp-server-dialback-implementations.html
-Parent_id: community/security-notices/
+Parent_id: community/security-notices
 Top_menu_show: false
 Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
-Content_layout: multiple-columns
-Inherit_sidebar: true
 Sidebar_menu_show: true
+Inherit_sidebar: community
+Content_layout: multiple-columns
 ---
 
 _Original Release Date: 2012-08-21_

--- a/content/pages/community/sponsors.md
+++ b/content/pages/community/sponsors.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Community
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: Chat / logs
-Sidebar_menu_elem_url_1: community/chat
-Sidebar_menu_elem_name_2: Mailing lists
-Sidebar_menu_elem_url_2: community/mailing-lists
-Sidebar_menu_elem_name_3: Membership
-Sidebar_menu_elem_url_3: community/membership
-Sidebar_menu_elem_name_4: Events
-Sidebar_menu_elem_url_4: community/events
-Sidebar_menu_elem_name_5: Sponsors
-Sidebar_menu_elem_url_5: community/sponsors
-Sidebar_menu_elem_name_6: Sponsorship
-Sidebar_menu_elem_url_6: community/sponsorship
+Inherit_sidebar: community
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/community/sponsorship.md
+++ b/content/pages/community/sponsorship.md
@@ -8,20 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_title: Community
-Sidebar_menu_size: 6
-Sidebar_menu_elem_name_1: Chat / logs
-Sidebar_menu_elem_url_1: community/chat
-Sidebar_menu_elem_name_2: Mailing lists
-Sidebar_menu_elem_url_2: community/mailing-lists
-Sidebar_menu_elem_name_3: Membership
-Sidebar_menu_elem_url_3: community/membership
-Sidebar_menu_elem_name_4: Events
-Sidebar_menu_elem_url_4: community/events
-Sidebar_menu_elem_name_5: Sponsors
-Sidebar_menu_elem_url_5: community/sponsors
-Sidebar_menu_elem_name_6: Sponsorship
-Sidebar_menu_elem_url_6: community/sponsorship
+Inherit_sidebar: community
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/getting-started/_index.md
+++ b/content/pages/getting-started/_index.md
@@ -7,7 +7,7 @@ Top_menu_show: true
 Top_Menu_order: 6
 Dropdown_menu_show: false
 Footer_show: false
-Content_layout: multiple-columns
+Content_layout: single-column
 ---
 
 Do you want to start chatting with XMPP? This page helps you get up and running in a matter of minutes.

--- a/content/pages/software/clients.md
+++ b/content/pages/software/clients.md
@@ -8,14 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 3
-Sidebar_menu_title: XMPP Software
-Sidebar_menu_elem_name_1: Clients
-Sidebar_menu_elem_url_1: software/clients
-Sidebar_menu_elem_name_2: Servers
-Sidebar_menu_elem_url_2: software/servers
-Sidebar_menu_elem_name_3: Libraries
-Sidebar_menu_elem_url_3: software/libraries
+Inherit_sidebar: software
 Content_layout: multiple-columns
 Template: software_list
 Swlist_Source: clients

--- a/content/pages/software/libraries.md
+++ b/content/pages/software/libraries.md
@@ -8,14 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 3
-Sidebar_menu_title: XMPP Software
-Sidebar_menu_elem_name_1: Clients
-Sidebar_menu_elem_url_1: software/clients
-Sidebar_menu_elem_name_2: Servers
-Sidebar_menu_elem_url_2: software/servers
-Sidebar_menu_elem_name_3: Libraries
-Sidebar_menu_elem_url_3: software/libraries
+Inherit_sidebar: software
 Content_layout: multiple-columns
 Template: software_list
 Swlist_Source: libraries

--- a/content/pages/software/servers.md
+++ b/content/pages/software/servers.md
@@ -8,14 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 3
-Sidebar_menu_title: XMPP Software
-Sidebar_menu_elem_name_1: Clients
-Sidebar_menu_elem_url_1: software/clients
-Sidebar_menu_elem_name_2: Servers
-Sidebar_menu_elem_url_2: software/servers
-Sidebar_menu_elem_name_3: Libraries
-Sidebar_menu_elem_url_3: software/libraries
+Inherit_sidebar: software
 Content_layout: multiple-columns
 Template: software_list
 Swlist_Source: servers

--- a/content/pages/uses/gaming.md
+++ b/content/pages/uses/gaming.md
@@ -8,18 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 5
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Online Gaming
-Sidebar_menu_elem_url_3: uses/gaming
-Sidebar_menu_elem_name_4: Social
-Sidebar_menu_elem_url_4: uses/social
-Sidebar_menu_elem_name_5: WebRTC
-Sidebar_menu_elem_url_5: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/instant-messaging.md
+++ b/content/pages/uses/instant-messaging.md
@@ -8,18 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 5
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Online Gaming
-Sidebar_menu_elem_url_3: uses/gaming
-Sidebar_menu_elem_name_4: Social
-Sidebar_menu_elem_url_4: uses/social
-Sidebar_menu_elem_name_5: WebRTC
-Sidebar_menu_elem_url_5: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/internet-of-things.md
+++ b/content/pages/uses/internet-of-things.md
@@ -8,18 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 5
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Online Gaming
-Sidebar_menu_elem_url_3: uses/gaming
-Sidebar_menu_elem_name_4: Social
-Sidebar_menu_elem_url_4: uses/social
-Sidebar_menu_elem_name_5: WebRTC
-Sidebar_menu_elem_url_5: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/iot/bindings.md
+++ b/content/pages/uses/iot/bindings.md
@@ -8,16 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 4
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Social
-Sidebar_menu_elem_url_3: uses/social
-Sidebar_menu_elem_name_4: WebRTC
-Sidebar_menu_elem_url_4: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/iot/interoperability.md
+++ b/content/pages/uses/iot/interoperability.md
@@ -8,16 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 4
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Social
-Sidebar_menu_elem_url_3: uses/social
-Sidebar_menu_elem_name_4: WebRTC
-Sidebar_menu_elem_url_4: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/iot/patterns.md
+++ b/content/pages/uses/iot/patterns.md
@@ -8,16 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 4
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Social
-Sidebar_menu_elem_url_3: uses/social
-Sidebar_menu_elem_name_4: WebRTC
-Sidebar_menu_elem_url_4: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/iot/provisioning.md
+++ b/content/pages/uses/iot/provisioning.md
@@ -8,16 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 4
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Social
-Sidebar_menu_elem_url_3: uses/social
-Sidebar_menu_elem_name_4: WebRTC
-Sidebar_menu_elem_url_4: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/iot/scalability.md
+++ b/content/pages/uses/iot/scalability.md
@@ -8,16 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 4
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Social
-Sidebar_menu_elem_url_3: uses/social
-Sidebar_menu_elem_name_4: WebRTC
-Sidebar_menu_elem_url_4: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/iot/security.md
+++ b/content/pages/uses/iot/security.md
@@ -8,16 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 4
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Social
-Sidebar_menu_elem_url_3: uses/social
-Sidebar_menu_elem_name_4: WebRTC
-Sidebar_menu_elem_url_4: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/iot/testimonials.md
+++ b/content/pages/uses/iot/testimonials.md
@@ -8,16 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 4
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Social
-Sidebar_menu_elem_url_3: uses/social
-Sidebar_menu_elem_name_4: WebRTC
-Sidebar_menu_elem_url_4: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/iot/things.md
+++ b/content/pages/uses/iot/things.md
@@ -8,16 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 4
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Social
-Sidebar_menu_elem_url_3: uses/social
-Sidebar_menu_elem_name_4: WebRTC
-Sidebar_menu_elem_url_4: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/iot/work-in-progress.md
+++ b/content/pages/uses/iot/work-in-progress.md
@@ -8,16 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 4
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Social
-Sidebar_menu_elem_url_3: uses/social
-Sidebar_menu_elem_name_4: WebRTC
-Sidebar_menu_elem_url_4: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/social.md
+++ b/content/pages/uses/social.md
@@ -8,18 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 5
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Online Gaming
-Sidebar_menu_elem_url_3: uses/gaming
-Sidebar_menu_elem_name_4: Social
-Sidebar_menu_elem_url_4: uses/social
-Sidebar_menu_elem_name_5: WebRTC
-Sidebar_menu_elem_url_5: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/content/pages/uses/webrtc.md
+++ b/content/pages/uses/webrtc.md
@@ -8,18 +8,7 @@ Top_Menu_order: -1
 Dropdown_menu_show: false
 Footer_show: false
 Sidebar_menu_show: true
-Sidebar_menu_size: 5
-Sidebar_menu_title: Uses of XMPP
-Sidebar_menu_elem_name_1: Instant Messaging
-Sidebar_menu_elem_url_1: uses/instant-messaging
-Sidebar_menu_elem_name_2: Internet of Things
-Sidebar_menu_elem_url_2: uses/internet-of-things
-Sidebar_menu_elem_name_3: Online Gaming
-Sidebar_menu_elem_url_3: uses/gaming
-Sidebar_menu_elem_name_4: Social
-Sidebar_menu_elem_url_4: uses/social
-Sidebar_menu_elem_name_5: WebRTC
-Sidebar_menu_elem_url_5: uses/webrtc
+Inherit_sidebar: uses
 Content_layout: multiple-columns
 ---
 

--- a/xmpp.org-theme/templates/page.html
+++ b/xmpp.org-theme/templates/page.html
@@ -15,24 +15,21 @@
   {%   set menu_title = [] %}
   {%   if page.sidebar_menu_title and menu_title.append(page.sidebar_menu_title) %}{% endif %}
   {%   set parts = page.url.split("/") %}
-  {%   set depth = parts|length if page.inherit_sidebar|default(boolean=True) else 1 %}
-  {%   for i in range(0, depth) %}
-  {%      set P_URL = parts|join("/") %}
-  {%      for parent in PAGES|selectattr("url", "equalto", P_URL) %}
-  {%         if parent.sidebar_menu_size|default(false) %}
-  {%            if menu_title.append(parent.sidebar_menu_title) %}{% endif %}
-  {%            set size = parent.sidebar_menu_size|int %}
-  {%            for i in range(1, size + 1) %}
-  {%               set E_URL = parent|attr('sidebar_menu_elem_url_'~(i|string)) %}
-  {%               set E_NAME = parent|attr('sidebar_menu_elem_name_'~(i|string)) %}
-  {%               if E_URL[-1] != '/' %}
-  {%                  set E_URL = E_URL + ".html" %}
-  {%               endif %}
-  {%               if links.append(( SITE_URL + "/" + E_URL, E_NAME )) %}{% endif %}
-  {%            endfor %}
-  {%         endif %}
-  {%      endfor %}
-  {%      set parts = parts[:-1] %}
+  {%   set depth = parts|length-1 if page.inherit_sidebar|default(boolean=True) else parts|length %}
+  {%   set P_URL = parts[:depth]|join("/") %}
+  {%   for parent in PAGES|selectattr("url", "equalto", P_URL) %}
+  {%      if parent.sidebar_menu_size|default(false) %}
+  {%         if menu_title.append(parent.sidebar_menu_title) %}{% endif %}
+  {%         set size = parent.sidebar_menu_size|int %}
+  {%         for i in range(1, size + 1) %}
+  {%            set E_URL = parent|attr('sidebar_menu_elem_url_'~(i|string)) %}
+  {%            set E_NAME = parent|attr('sidebar_menu_elem_name_'~(i|string)) %}
+  {%            if E_URL[-1] != '/' %}
+  {%               set E_URL = E_URL + ".html" %}
+  {%            endif %}
+  {%            if links.append(( SITE_URL + "/" + E_URL, E_NAME )) %}{% endif %}
+  {%         endfor %}
+  {%      endif %}
   {%   endfor %}
   {%   set menu_title = menu_title[0] %}
        <h4>{{ menu_title }}</h4>

--- a/xmpp.org-theme/templates/page.html
+++ b/xmpp.org-theme/templates/page.html
@@ -14,16 +14,14 @@
   {%   set links = [] %}
   {%   set menu_title = [] %}
   {%   if page.sidebar_menu_title and menu_title.append(page.sidebar_menu_title) %}{% endif %}
-  {%   set parts = page.url.split("/") %}
-  {%   set depth = parts|length-1 if page.inherit_sidebar|default(boolean=True) else parts|length %}
-  {%   set P_URL = parts[:depth]|join("/") %}
-  {%   for parent in PAGES|selectattr("url", "equalto", P_URL) %}
-  {%      if parent.sidebar_menu_size|default(false) %}
-  {%         if menu_title.append(parent.sidebar_menu_title) %}{% endif %}
-  {%         set size = parent.sidebar_menu_size|int %}
+  {%   set P_URL = page.inherit_sidebar|default(page.url) %}
+  {%   for sidebar_source in PAGES|selectattr("url", "equalto", P_URL) %}
+  {%      if sidebar_source.sidebar_menu_size|default(false) %}
+  {%         if menu_title.append(sidebar_source.sidebar_menu_title) %}{% endif %}
+  {%         set size = sidebar_source.sidebar_menu_size|int %}
   {%         for i in range(1, size + 1) %}
-  {%            set E_URL = parent|attr('sidebar_menu_elem_url_'~(i|string)) %}
-  {%            set E_NAME = parent|attr('sidebar_menu_elem_name_'~(i|string)) %}
+  {%            set E_URL = sidebar_source|attr('sidebar_menu_elem_url_'~(i|string)) %}
+  {%            set E_NAME = sidebar_source|attr('sidebar_menu_elem_name_'~(i|string)) %}
   {%            if E_URL[-1] != '/' %}
   {%               set E_URL = E_URL + ".html" %}
   {%            endif %}


### PR DESCRIPTION
Most pages have a menu in a side bar. Once upon a time, this side bar menu was inherited, but that mechanism now fails. To work around this problem, the sidebar definition of a set of pages is copied across many other pages. Over time, modifications sneak in that do not get copied, which makes for a messy structure.

The commits in this PR reflect my journey through discovering how things work. I ended up with replacing the very flexible, but equally complex inheritance-from-an-ancestor implementation to an implementation where the sidebar is inherited from a page that is directly referenced. 