### PR TITLE
Add opendomain.org attribution

### DIFF
--- a/xmpp.org-theme/templates/footer.html
+++ b/xmpp.org-theme/templates/footer.html
@@ -13,6 +13,7 @@
 </div>
 <div class="footer-github">
   <p><a href="//github.com/xsf/xmpp.org"><img src="/theme/images/github.svg"></a>This site is organized in the open on GitHub. <a href="//github.com/xsf/xmpp.org">Suggest changes</a>.</p>
+  <p>The xmpp.org domain was generously donated by <a href="opendomain.org">OpenDomain.org</a>.</p>
 </div>
 <footer class="top-bar">
   <section class="top-bar-section">


### PR DESCRIPTION
Fixes #497.

Desktop Screenshot:
![screen shot 2019-01-31 at 17 04 34](https://user-images.githubusercontent.com/271710/52067206-61e2c480-257a-11e9-83b8-f4623af9fd69.png)

Mobile Screenshot:
![screen shot 2019-01-31 at 17 04 29](https://user-images.githubusercontent.com/271710/52067207-61e2c480-257a-11e9-9fe3-ce7f40df56b7.png)
