### PR TITLE
Replace list.jabber.at with compliance.conversations.im

### DIFF
--- a/content/pages/getting-started/_index.md
+++ b/content/pages/getting-started/_index.md
@@ -24,7 +24,7 @@ There are [many, many XMPP clients](/software/clients) for you to choose from. T
 
 # 2. Create an account
 
-As with e-mail, you'll need an account with a service provider. Again, there are [plenty of choices](https://list.jabber.at/), from which these are only a couple of the more popular ones:
+As with e-mail, you'll need an account with a service provider. Again, there are [plenty of choices](https://compliance.conversations.im/), from which these are only a couple of the more popular ones:
 
 * [xmpp.jp](https://www.xmpp.jp/signup)
 * [jabber.ru](https://jabber.ru/user/register)


### PR DESCRIPTION
Replacing outdated server catalog with a new. New list XMPP server freedom and independent. Anyone can add their server in a couple of seconds. The new catalog is more good, as it better describes the capabilities of the servers, and not only lists their names.
This directory is more useful for new XMPP users than meaningless enumeration of server names.