### PR TITLE
Add a header-banner CSS class for the next summit or event

### DIFF
--- a/xmpp.org-theme/sass/components/header.sass
+++ b/xmpp.org-theme/sass/components/header.sass
@@ -25,3 +25,11 @@
 
 .header-internal h1, .header-internal h1 a
   color: $dkblue
+
+.header-banner
+  color: white
+  font-size: 120%
+  background: #008CBA
+  padding: 20px
+  display: block
+  clear: both


### PR DESCRIPTION
This is a follow-up to #519, to remember the banner’s CSS values for the next time we decide to set one.

Use `<a class="header-banner" href="/community/events/summit24">Blah blah blah</a>` for the 24th summit for instance.