### PR TITLE
Remove OneTeam

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -383,16 +383,6 @@
         "url": "http://mozilla.org/thunderbird"
     },
     {
-        "last_renewed": "2018-03-30T10:27:25",
-        "name": "OneTeam",
-        "platforms": [
-            "Linux",
-            "macOS",
-            "Windows"
-        ],
-        "url": "http://oneteam.im"
-    },
-    {
         "last_renewed": "2018-03-31T06:00:00",
         "name": "Pidgin",
         "platforms": [


### PR DESCRIPTION
OneTeam is discontinued by ProcessOne. It's URL does no longer respond to requests.