### PR TITLE
Update dates

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -96,7 +96,7 @@
         "url": "https://candy-chat.github.io/candy/"
     },
     {
-        "last_renewed": "2017-04-19T14:37:00",
+        "last_renewed": "2019-04-22T14:37:00",
         "name": "ChatSecure",
         "platforms": [
             "iOS"
@@ -114,7 +114,7 @@
         "url": "http://coccinella.im"
     },
     {
-        "last_renewed": "2018-09-21T07:35:39",
+        "last_renewed": "2019-05-06T07:35:39",
         "name": "Conversations",
         "platforms": [
             "Android"
@@ -122,7 +122,7 @@
         "url": "https://github.com/siacs/Conversations"
     },
     {
-        "last_renewed": "2018-08-29T15:00:00",
+        "last_renewed": "2019-04-04T15:00:00",
         "name": "Converse",
         "platforms": [
             "Browser"
@@ -180,7 +180,7 @@
         "url": "http://developer.pidgin.im"
     },
     {
-        "last_renewed": "2019-04-03T08:32:00",
+        "last_renewed": "2019-04-23T08:32:00",
         "name": "Gajim",
         "platforms": [
             "Linux",
@@ -345,7 +345,7 @@
         "url": "http://miranda-ng.org"
     },
     {
-        "last_renewed": "2018-06-05T13:12:35",
+        "last_renewed": "2019-05-08T13:12:35",
         "name": "Monal IM",
         "platforms": [
             "iOS",
@@ -638,7 +638,7 @@
         "url": "https://yaxim.org"
     },
     {
-        "last_renewed": "2017-04-21T14:01:57",
+        "last_renewed": "2019-04-30T14:01:57",
         "name": "Zom",
         "platforms": [
             "Android",


### PR DESCRIPTION
I was under impression that a client is shown in the list if its renew date is fairly recent. Or is there another mechanism? Say, Pidgin is not on the list, its renew date is 2018-03-31. Maybe this date should be not older than a year for a client to show up?

Also, it seems that renew date should be a date when someone submits a PR with an update for that client. But i have just added dates of actual last release for some more or less known clients (ChatSecure is not showing on the list, but it had a release a month ago, so i think it should be there).