### PR TITLE
Add Karlsruhe and The Hague sprints and show banner for them

### DIFF
--- a/content/pages/community/events.md
+++ b/content/pages/community/events.md
@@ -39,6 +39,7 @@ page](https://wiki.xmpp.org/web/Sprints).
 ### Upcoming
 
 * [Karlsruhe, May 30th - June 2nd, 2019](https://wiki.xmpp.org/web/Sprints/2019_May_Karlsruhe)
+* [The Hague, June 7-9th, 2019](https://wiki.xmpp.org/web/Sprints/2019_June_The_Hague)
 * [Your event here!](https://github.com/xsf/xmpp.org/edit/master/content/pages/community/events.md)
 
 ### Past

--- a/content/pages/index.html
+++ b/content/pages/index.html
@@ -11,6 +11,9 @@
     <meta name="content_layout" content="wide"/>
 </head>
 <body>
+  <a class="sprint-banner" style="color: white; font-size: 120%; background: #008CBA; padding: 20px; display: block; clear: both;" href="https://xmpp.org/community/events.html">
+    Next XMPP Sprints will happen in Karlsruhe (May 30th - June 2nd, 2019) and The Hague (June 7-9th, 2019). Click for more info!
+  </a>
   <header class="header-home">
     <div class="hero">
       <h1>The universal messaging standard</h1>


### PR DESCRIPTION
This adds both the Karlsruhe sprint and the The Hague sprint to the community events page.

Additionally, a banner is shown on the front page (with a link to community events).