### PR TITLE
Updated platforms.json and added UWPX

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -565,6 +565,14 @@
         "url": "https://trillian.im"
     },
     {
+        "last_renewed": "2019-06-11T01:10:47",
+        "name": "UWPX",
+        "platforms": [
+            "Windows 10"
+        ],
+        "url": "https://uwpx.org"
+    },
+    {
         "last_renewed": null,
         "name": "V&V Messenger",
         "platforms": [

--- a/data/clients.json
+++ b/data/clients.json
@@ -568,7 +568,7 @@
         "last_renewed": "2019-06-11T01:10:47",
         "name": "UWPX",
         "platforms": [
-            "Windows 10"
+            "Windows"
         ],
         "url": "https://uwpx.org"
     },

--- a/data/platforms.json
+++ b/data/platforms.json
@@ -7,5 +7,6 @@
     "macOS",
     "Other",
     "Solaris",
-    "Windows"
+    "Windows",
+    "Windows 10"
 ]

--- a/data/platforms.json
+++ b/data/platforms.json
@@ -7,6 +7,5 @@
     "macOS",
     "Other",
     "Solaris",
-    "Windows",
-    "Windows 10"
+    "Windows"
 ]


### PR DESCRIPTION
I added [UWPX](https://uwpx.org/) to the `clients.json`.

I also added `Windows 10` to the `platforms.json`.
Why:
* UWPX is a Windows 10 client app that runs only on Windows **10** devices not on for example Windows 7/8/...
* Windows 10 as a platform includes: Xbox, HoloLens, Windows Phone, PC, ...