### PR TITLE
Remove Karlsruhe and The Hague sprint banner

### DIFF
--- a/content/pages/community/events.md
+++ b/content/pages/community/events.md
@@ -38,12 +38,12 @@ page](https://wiki.xmpp.org/web/Sprints).
 
 ### Upcoming
 
-* [Karlsruhe, May 30th - June 2nd, 2019](https://wiki.xmpp.org/web/Sprints/2019_May_Karlsruhe)
-* [The Hague, June 7-9th, 2019](https://wiki.xmpp.org/web/Sprints/2019_June_The_Hague)
 * [Your event here!](https://github.com/xsf/xmpp.org/edit/master/content/pages/community/events.md)
 
 ### Past
 
+* [The Hague, June 7-9th, 2019](https://wiki.xmpp.org/web/Sprints/2019_June_The_Hague)
+* [Karlsruhe, May 30th - June 2nd, 2019](https://wiki.xmpp.org/web/Sprints/2019_May_Karlsruhe)
 * [Berlin, March 30-31st, 2019](https://wiki.xmpp.org/web/Sprints/2019_March_Berlin) (at GPN19)
 * [Brussels, January 30th, 2019](https://wiki.xmpp.org/web/Sprints/2019_January_Brussels) (around FOSDEM)
 * [Dusseldorf, November 17-18th, 2018](https://wiki.xmpp.org/web/Sprints/2018_November_Dusseldorf)

--- a/content/pages/index.html
+++ b/content/pages/index.html
@@ -11,9 +11,6 @@
     <meta name="content_layout" content="wide"/>
 </head>
 <body>
-  <a class="sprint-banner" style="color: white; font-size: 120%; background: #008CBA; padding: 20px; display: block; clear: both;" href="https://xmpp.org/community/events.html">
-    Next XMPP Sprints will happen in Karlsruhe (May 30th - June 2nd, 2019) and The Hague (June 7-9th, 2019). Click for more info!
-  </a>
   <header class="header-home">
     <div class="hero">
       <h1>The universal messaging standard</h1>


### PR DESCRIPTION
This moves both the Karlsruhe sprint and the The Hague sprint to the
past events section (events page). Additionally, this removes the banner
on the front page.