### PR TITLE
Updates to the gaming page

### DIFF
--- a/content/pages/uses/gaming.md
+++ b/content/pages/uses/gaming.md
@@ -14,16 +14,17 @@ Content_layout: multiple-columns
 
 XMPP provides a scalable platform for real-time signaling, chat and online status (presence). This is used by an increasing number of online games for [matchmaking](https://en.wikipedia.org/wiki/Matchmaking_(video_games)), in-game chat and other activities.
 
-## Online Games using XMPP-based Chat and Matchmaking
+## Online Games using XMPP
 
-There is a growing number of games adopting XMPP for real-time signaling and chat:
+There is a growing number of games adopting XMPP for real-time signaling, push notifications and chat:
 
-| Users        | Game / Community                | Description                            | Since |
-|--------------|---------------------------------|----------------------------------------|-------|
-|  ~40 million | [Origin](https://www.origin.com/) by Electronic Arts | Origin is an online gaming and game distribution platform. [XMPP is used internally](https://blog.joelj.org/connect-to-ea-origin-chat-using-xmpp-jabber-and-pidgin/) for the buddy and chat system. | 2011 |
-|  ~27 million | [League of Legends](https://leagueoflegends.com) by Riot Games | One of the largest online video games [using XMPP](http://highscalability.com/blog/2014/10/13/how-league-of-legends-scaled-chat-to-70-million-players-it-t.html) for chat and game invitations. | 2009 |
-|  ~16 million | [Neverwinter](http://crypticstudios.com/neverwinter) | Neverwinter is a free-to-play, action MMORPG based on the acclaimed Dungeons & Dragons fantasy roleplaying game using XMPP for chat, presence, group chat | 2013 |
-|  ~10 million | [Fortnite](https://www.epicgames.com/fortnite/) by Epic Games | A cooperative survival game [using XMPP](https://www.epicgames.com/fortnite/en-US/news/postmortem-of-service-outage-at-3-4m-ccu) for presence, push, whispers and group chat | 2017 |
-|  ~1 million  | [EVE Online](https://www.eveonline.com/) | EVE Online has [switched to XMPP for the in-game chat backend](https://www.eveonline.com/article/p4i0qx/new-chat-backend-coming-with-the-march-release) | 2018 |
-|  ~900k       | [Star Trek Online](http://crypticstudios.com/startrek) | A free-to-play sci-fi MMORPG game based on Star Trek using XMPP for chat, presence, group chat | 2010 |
-|  ~345k       | [Champions Online](http://crypticstudios.com/champions) | Champions Online is a free-to-play superhero MMORPG based on the Champions role-playing game using XMPP for chat, presence, group chat | 2010 |
+| Users         | Game / Community                | Description                            | Since |
+|---------------|---------------------------------|----------------------------------------|-------|
+|  ~34 million  | [Nintendo Switch](https://www.nintendo.com/switch/) | The Nintendo Switch video game console [uses the Ejabberd XMPP server for push notifications](https://blog.process-one.net/ejabberd-nintendo-switch-npns/). | 2019 |
+|  ~1 million   | [EVE Online](https://www.eveonline.com/) | EVE Online has [switched to XMPP for the in-game chat backend](https://www.eveonline.com/article/p4i0qx/new-chat-backend-coming-with-the-march-release) | 2018 |
+|  ~250 million | [Fortnite](https://www.epicgames.com/fortnite/) | A cooperative survival game [using XMPP](https://www.epicgames.com/fortnite/en-US/news/postmortem-of-service-outage-at-3-4m-ccu) for presence, push, whispers and group chat | 2017 |
+|  ~16 million  | [Neverwinter](http://crypticstudios.com/neverwinter) | Neverwinter is a free-to-play, action MMORPG based on the acclaimed Dungeons & Dragons fantasy roleplaying game using XMPP for chat, presence, group chat | 2013 |
+|  ~40 million  | [Origin](https://www.origin.com/) | Origin is an online gaming and game distribution platform. [XMPP is used internally](https://blog.joelj.org/connect-to-ea-origin-chat-using-xmpp-jabber-and-pidgin/) for the buddy and chat system. | 2011 |
+|  ~900k        | [Star Trek Online](http://crypticstudios.com/startrek) | A free-to-play sci-fi MMORPG game based on Star Trek using XMPP for chat, presence, group chat | 2010 |
+|  ~345k        | [Champions Online](http://crypticstudios.com/champions) | Champions Online is a free-to-play superhero MMORPG based on the Champions role-playing game using XMPP for chat, presence, group chat | 2010 |
+|  ~27 million  | [League of Legends](https://leagueoflegends.com) | One of the largest online video games [using XMPP](http://highscalability.com/blog/2014/10/13/how-league-of-legends-scaled-chat-to-70-million-players-it-t.html) for chat and game invitations. | 2009 |


### PR DESCRIPTION
- Mention the Nintendo Switch
- Sort list by year
- Remove the game maker from the first column since we don't use it
  uniformly and it seems unnecessary.