### PR TITLE
Add a DOAP URL for each implementation we know of

### DIFF
--- a/data/README.rst
+++ b/data/README.rst
@@ -38,7 +38,7 @@ The tool will ask for confirmation::
    }
   is this okay? [y/n]
 
-After confirmation, it writes the changes to the ``clients.json``. This works just the same for ``servers.json`` and ``libraries.json``. You can then add and commit the changes to git as usual. **Validate** that your entry is correct using the ``./lint-tool.py`` on the respective JSON file and then make a Pull Request on GitHub.
+After confirmation, it writes the changes to the ``clients.json``. This works just the same for ``servers.json`` and ``libraries.json``. You can then add and commit the changes to git as usual. **Validate** that your entry is correct using the ``./lint-list.py`` on the respective JSON file and then make a Pull Request on GitHub.
 
 
 Updating information
@@ -82,7 +82,7 @@ Do not set ``--no-ask`` and always be sure to review that your changes do what y
 
 If you do not know how to spell your project correctly, leave out the ``NAME`` argument; the tool will list the project it knows.
 
-Do not forget to **validate** that your entry is correct using the ``./lint-tool.py`` on the respective JSON file and then make a Pull Request on GitHub.
+Do not forget to **validate** that your entry is correct using the ``./lint-list.py`` on the respective JSON file and then make a Pull Request on GitHub.
 
 
 Add a new entry

--- a/data/README.rst
+++ b/data/README.rst
@@ -96,6 +96,7 @@ There is no tooling for that. Add the following template to the respective ``jso
           "platforms": ["GNU Hurd", "Plan9"],
           "last_renewed": null,
           "name": "My Fancy New Client",
+          "doap": "https://myfancyclient.example/doap.rdf",
           "url": "https://myfancyclient.example"
       }
 

--- a/data/clients.json
+++ b/data/clients.json
@@ -5,6 +5,7 @@
         "platforms": [
             "macOS"
         ],
+        "doap": null,
         "url": "https://adium.im"
     },
     {
@@ -13,6 +14,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "http://aqq.eu"
     },
     {
@@ -25,6 +27,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://astrachat.com"
     },
     {
@@ -33,6 +36,7 @@
         "platforms": [
             "macOS"
         ],
+        "doap": null,
         "url": "https://beagle.im"
     },
     {
@@ -41,6 +45,7 @@
         "platforms": [
             "Android"
         ],
+        "doap": null,
         "url": "https://beem-project.com"
     },
     {
@@ -49,6 +54,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "https://www.bitlbee.org"
     },
     {
@@ -59,6 +65,7 @@
             "Blackberry",
             "Nokia Symbian"
         ],
+        "doap": null,
         "url": "http://www.bluejabb.com"
     },
     {
@@ -67,6 +74,7 @@
         "platforms": [
             "iOS"
         ],
+        "doap": null,
         "url": "https://itunes.apple.com/app/boogie-chat/id779423907"
     },
     {
@@ -75,6 +83,7 @@
         "platforms": [
             "Android"
         ],
+        "doap": null,
         "url": "https://yaxim.org/bruno/"
     },
     {
@@ -85,6 +94,7 @@
             "Mobile",
             "Web"
         ],
+        "doap": null,
         "url": "http://buddycloud.com"
     },
     {
@@ -93,6 +103,7 @@
         "platforms": [
             "Browser"
         ],
+        "doap": null,
         "url": "https://candy-chat.github.io/candy/"
     },
     {
@@ -101,6 +112,7 @@
         "platforms": [
             "iOS"
         ],
+        "doap": null,
         "url": "https://chatsecure.org/"
     },
     {
@@ -111,6 +123,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://coccinella.im"
     },
     {
@@ -119,6 +132,7 @@
         "platforms": [
             "Android"
         ],
+        "doap": null,
         "url": "https://github.com/siacs/Conversations"
     },
     {
@@ -127,6 +141,7 @@
         "platforms": [
             "Browser"
         ],
+        "doap": null,
         "url": "https://conversejs.org/"
     },
     {
@@ -135,6 +150,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "http://coversant.com"
     },
     {
@@ -143,6 +159,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": "https://raw.githubusercontent.com/dino/dino/master/dino.doap",
         "url": "https://dino.im"
     },
     {
@@ -151,6 +168,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.emclient.com"
     },
     {
@@ -159,6 +177,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "https://wiki.gnome.org/Apps/Empathy"
     },
     {
@@ -169,6 +188,7 @@
             "Other",
             "Windows"
         ],
+        "doap": null,
         "url": "https://eyecu.opiums.eu"
     },
     {
@@ -177,6 +197,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "https://developer.pidgin.im"
     },
     {
@@ -186,6 +207,7 @@
             "Linux",
             "Windows"
         ],
+        "doap": "https://dev.gajim.org/gajim/gajim/raw/master/data/gajim.doap",
         "url": "https://gajim.org"
     },
     {
@@ -194,6 +216,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "https://gnufreetalk.github.io/"
     },
     {
@@ -202,6 +225,7 @@
         "platforms": [
             "IBM i"
         ],
+        "doap": null,
         "url": "https://www.bvstools.com"
     },
     {
@@ -211,6 +235,7 @@
             "iOS",
             "macOS"
         ],
+        "doap": null,
         "url": "https://www.shape.ag/en/"
     },
     {
@@ -221,6 +246,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "http://instantbird.com"
     },
     {
@@ -230,6 +256,7 @@
             "Console",
             "Text-Mode"
         ],
+        "doap": null,
         "url": "https://cybione.org"
     },
     {
@@ -238,6 +265,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "http://emacs-jabber.sourceforge.net"
     },
     {
@@ -248,6 +276,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.jabbim.com"
     },
     {
@@ -256,6 +285,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "http://jajc.jrudevels.org"
     },
     {
@@ -264,6 +294,7 @@
         "platforms": [
             "Browser"
         ],
+        "doap": null,
         "url": "http://jappix.org"
     },
     {
@@ -274,6 +305,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://desktop.jitsi.org"
     },
     {
@@ -282,6 +314,7 @@
         "platforms": [
             "Browser"
         ],
+        "doap": null,
         "url": "https://www.jsxc.org"
     },
     {
@@ -292,6 +325,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "http://kadu.net"
     },
     {
@@ -304,6 +338,7 @@
             "Other",
             "Windows"
         ],
+        "doap": null,
         "url": "https://kaidan.im"
     },
     {
@@ -312,6 +347,7 @@
         "platforms": [
             "Browser"
         ],
+        "doap": null,
         "url": "http://getkaiwa.com/"
     },
     {
@@ -320,6 +356,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "https://userbase.kde.org/Kopete"
     },
     {
@@ -328,6 +365,7 @@
         "platforms": [
             "Other"
         ],
+        "doap": null,
         "url": "https://mcabber.com"
     },
     {
@@ -336,6 +374,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "http://miranda-im.org"
     },
     {
@@ -344,6 +383,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.miranda-ng.org/en/"
     },
     {
@@ -353,6 +393,7 @@
             "iOS",
             "macOS"
         ],
+        "doap": null,
         "url": "https://monal.im"
     },
     {
@@ -365,6 +406,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": "https://raw.githubusercontent.com/movim/movim/master/doap.xml",
         "url": "https://movim.eu"
     },
     {
@@ -375,6 +417,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.thunderbird.net/en-US/"
     },
     {
@@ -385,6 +428,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://pidgin.im"
     },
     {
@@ -394,6 +438,7 @@
             "Linux",
             "macOS"
         ],
+        "doap": "https://lab.louiz.org/poezio/poezio/raw/master/data/doap.xml",
         "url": "https://poez.io/en/"
     },
     {
@@ -404,6 +449,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://profanity-im.github.io/"
     },
     {
@@ -414,6 +460,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://psi-im.org"
     },
     {
@@ -424,6 +471,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://psi-plus.com"
     },
     {
@@ -432,6 +480,7 @@
         "platforms": [
             "Browser"
         ],
+        "doap": null,
         "url": "https://www.igniterealtime.org/projects/pade/"
     },
     {
@@ -440,6 +489,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "http://forum.qip.ru"
     },
     {
@@ -450,6 +500,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://qutim.org"
     },
     {
@@ -461,6 +512,7 @@
             "Linux",
             "Other"
         ],
+        "doap": null,
         "url": "https://salut-a-toi.org/"
     },
     {
@@ -471,6 +523,7 @@
             "Linux",
             "Windows"
         ],
+        "doap": null,
         "url": "http://www.sim-im.org/index.php?title=Main_Page"
     },
     {
@@ -479,6 +532,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "https://waher.se/IoTGateway/SimpleIoTClient.md"
     },
     {
@@ -487,6 +541,7 @@
         "platforms": [
             "iOS"
         ],
+        "doap": null,
         "url": "https://siskin.im"
     },
     {
@@ -497,6 +552,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://smuxi.im/"
     },
     {
@@ -507,6 +563,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://igniterealtime.org/projects/spark/"
     },
     {
@@ -515,6 +572,7 @@
         "platforms": [
             "Browser"
         ],
+        "doap": null,
         "url": "https://igniterealtime.org/projects/sparkweb/index.jsp"
     },
     {
@@ -525,6 +583,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://swift.im"
     },
     {
@@ -533,6 +592,7 @@
         "platforms": [
             "Mobile"
         ],
+        "doap": null,
         "url": "http://talkonaut.com"
     },
     {
@@ -541,6 +601,7 @@
         "platforms": [
             "Android"
         ],
+        "doap": null,
         "url": "https://tigase.net/content/tigase-messenger-android"
     },
     {
@@ -551,6 +612,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "http://tkabber.jabber.ru"
     },
     {
@@ -564,6 +626,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://trillian.im"
     },
     {
@@ -572,6 +635,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "https://uwpx.org"
     },
     {
@@ -580,6 +644,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.altertech.com/products/vv/"
     },
     {
@@ -588,6 +653,7 @@
         "platforms": [
             "BlackBerry"
         ],
+        "doap": null,
         "url": "https://www.vayusphere.com"
     },
     {
@@ -596,6 +662,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "https://archive.codeplex.com/?p=vstalk"
     },
     {
@@ -604,6 +671,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "https://wtw.im/"
     },
     {
@@ -614,6 +682,7 @@
             "Browser",
             "iOS"
         ],
+        "doap": null,
         "url": "https://www.xabber.com"
     },
     {
@@ -623,6 +692,7 @@
             "Linux",
             "macOS"
         ],
+        "doap": null,
         "url": "https://github.com/agl/xmpp-client"
     },
     {
@@ -631,6 +701,7 @@
         "platforms": [
             "Browser"
         ],
+        "doap": null,
         "url": "https://babelmonkeys.de"
     },
     {
@@ -639,6 +710,7 @@
         "platforms": [
             "Browser"
         ],
+        "doap": null,
         "url": "https://github.com/udayg/xmppwebchat"
     },
     {
@@ -647,6 +719,7 @@
         "platforms": [
             "Android"
         ],
+        "doap": null,
         "url": "https://yaxim.org"
     },
     {
@@ -656,6 +729,7 @@
             "Android",
             "iOS"
         ],
+        "doap": null,
         "url": "https://zom.im/"
     }
 ]

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -5,6 +5,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "https://github.com/horazont/aioxmpp"
     },
     {
@@ -13,6 +14,7 @@
         "platforms": [
             "Perl"
         ],
+        "doap": null,
         "url": "http://ta-sa.org"
     },
     {
@@ -21,6 +23,7 @@
         "platforms": [
             "Java"
         ],
+        "doap": null,
         "url": "https://mina.apache.org/vysper-project"
     }
 ,
@@ -30,6 +33,7 @@
         "platforms": [
             "C#"
         ],
+        "doap": null,
         "url": "https://github.com/araditc/Artalk.Xmpp"
     },
     {
@@ -39,6 +43,7 @@
             "ActionScript",
             "Flash"
         ],
+        "doap": null,
         "url": "https://github.com/lyokato/as3xmppclient"
     },
     {
@@ -47,6 +52,7 @@
         "platforms": [
             "Ada"
         ],
+        "doap": null,
         "url": "http://orge.ada-ru.org"
     },
     {
@@ -55,6 +61,7 @@
         "platforms": [
             "Java"
         ],
+        "doap": null,
         "url": "http://xmpp.rocks"
     },
     {
@@ -63,6 +70,7 @@
         "platforms": [
             "Ruby"
         ],
+        "doap": null,
         "url": "http://adhearsion.com"
     },
     {
@@ -71,6 +79,7 @@
         "platforms": [
             "Lisp"
         ],
+        "doap": null,
         "url": "http://common-lisp.net"
     },
     {
@@ -79,6 +88,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "https://github.com/dojo/dojox"
     },
     {
@@ -87,6 +97,7 @@
         "platforms": [
             "C++"
         ],
+        "doap": null,
         "url": "https://github.com/stefandxm/dxmpp"
     },
     {
@@ -95,6 +106,7 @@
         "platforms": [
             "Java"
         ],
+        "doap": null,
         "url": "https://github.com/jdevelop/feridian"
     },
     {
@@ -103,6 +115,7 @@
         "platforms": [
             "Eiffel"
         ],
+        "doap": null,
         "url": "https://www.eiffel.org/resources/libraries/eiffel-xmpp"
     },
     {
@@ -111,6 +124,7 @@
         "platforms": [
             "Java"
         ],
+        "doap": null,
         "url": "https://github.com/EmiteGWT/emite"
     },
     {
@@ -120,6 +134,7 @@
             "Elixir",
             "Erlang"
         ],
+        "doap": null,
         "url": "https://github.com/processone/xmpp"
     },
     {
@@ -128,6 +143,7 @@
         "platforms": [
             "Erlang"
         ],
+        "doap": null,
         "url": "https://github.com/esl/escalus"
     },
     {
@@ -136,6 +152,7 @@
         "platforms": [
             "Erlang"
         ],
+        "doap": null,
         "url": "http://exmpp.org"
     },
     {
@@ -144,6 +161,7 @@
         "platforms": [
             "Go"
         ],
+        "doap": null,
         "url": "https://github.com/FluuxIO/go-xmpp"
     },
     {
@@ -152,6 +170,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "https://github.com/theozaurus/frabjous"
     },
     {
@@ -160,6 +179,7 @@
         "platforms": [
             "C++"
         ],
+        "doap": null,
         "url": "https://camaya.net/"
     },
     {
@@ -168,6 +188,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "https://github.com/Lawouach/headstock"
     },
     {
@@ -176,6 +197,7 @@
         "platforms": [
             "Haskell"
         ],
+        "doap": null,
         "url": "http://\u05d7\u05e0\u05d5\u05da.se"
     },
     {
@@ -184,6 +206,7 @@
         "platforms": [
             "haXe"
         ],
+        "doap": null,
         "url": "http://hxmpp.disktree.net"
     },
     {
@@ -192,6 +215,7 @@
         "platforms": [
             "C"
         ],
+        "doap": null,
         "url": "http://code.google.com/p/iksemel"
     },
     {
@@ -200,6 +224,7 @@
         "platforms": [
             "ActiveX, C++, C#,"
         ],
+        "doap": null,
         "url": "https://www.nsoftware.com/ipworks/"
     },
     {
@@ -208,6 +233,7 @@
         "platforms": [
             "C++"
         ],
+        "doap": null,
         "url": "https://github.com/psi-im/iris"
     },
     {
@@ -216,6 +242,7 @@
         "platforms": [
             "Java"
         ],
+        "doap": null,
         "url": "https://java.net/projects/jso"
     },
     {
@@ -226,6 +253,7 @@
             "C#",
             "Mono"
         ],
+        "doap": null,
         "url": "https://code.google.com/archive/p/jabber-net/"
     },
     {
@@ -234,6 +262,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "http://jabberpy.sourceforge.net/"
     },
     {
@@ -242,6 +271,7 @@
         "platforms": [
             "Tcl"
         ],
+        "doap": null,
         "url": "http://coccinella.im"
     },
     {
@@ -250,6 +280,7 @@
         "platforms": [
             "PHP"
         ],
+        "doap": null,
         "url": "https://github.com/jaxl/JAXL"
     },
     {
@@ -258,6 +289,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "https://github.com/maxpowel/jQuery-XMPP-plugin"
     },
     {
@@ -267,6 +299,7 @@
             "C++",
             "Qt"
         ],
+        "doap": null,
         "url": "http://qutim.org"
     },
     {
@@ -275,6 +308,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "https://github.com/sstrigler/JSJaC"
     },
     {
@@ -284,6 +318,7 @@
             "C",
             "C++"
         ],
+        "doap": null,
         "url": "https://developer.pidgin.im/wiki/WhatIsLibpurple"
     },
     {
@@ -292,6 +327,7 @@
         "platforms": [
             "C"
         ],
+        "doap": null,
         "url": "http://strophe.im"
     },
     {
@@ -300,6 +336,7 @@
         "platforms": [
             "PHP"
         ],
+        "doap": null,
         "url": "https://github.com/myYearbook/lightr"
     },
     {
@@ -308,6 +345,7 @@
         "platforms": [
             "C"
         ],
+        "doap": null,
         "url": "https://github.com/mcabber/loudmouth"
     },
     {
@@ -318,6 +356,7 @@
             "C#",
             "Mono"
         ],
+        "doap": null,
         "url": "https://www.ag-software.net/matrix-xmpp-sdk/"
     },
     {
@@ -328,6 +367,7 @@
             ".NET Standard",
             "C#"
         ],
+        "doap": null,
         "url": "https://www.ag-software.net/matrix-vnext/"
     },
     {
@@ -336,6 +376,7 @@
         "platforms": [
             "Perl"
         ],
+        "doap": null,
         "url": null
     },
     {
@@ -344,6 +385,7 @@
         "platforms": [
             "C++"
         ],
+        "doap": null,
         "url": null
     },
     {
@@ -352,6 +394,7 @@
         "platforms": [
             "Haskell"
         ],
+        "doap": null,
         "url": "https://github.com/pontarius/pontarius-xmpp/"
     },
     {
@@ -360,6 +403,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "http://pyxmpp.jajcus.net/pyxmpp.html"
     },
     {
@@ -368,6 +412,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "https://github.com/Jajcus/pyxmpp2"
     },
     {
@@ -376,6 +421,7 @@
         "platforms": [
             "C++"
         ],
+        "doap": null,
         "url": "http://qxmpp.org"
     },
     {
@@ -385,6 +431,7 @@
             "ActionScript",
             "Flash"
         ],
+        "doap": null,
         "url": "https://code.google.com/archive/p/seesmic-as3-xmpp"
     },
     {
@@ -395,6 +442,7 @@
             "C#",
             "Mono"
         ],
+        "doap": null,
         "url": "https://github.com/pgstath/Sharp.Xmpp"
     },
     {
@@ -403,6 +451,7 @@
         "platforms": [
             "Ruby"
         ],
+        "doap": null,
         "url": "https://github.com/julien51/skates"
     },
     {
@@ -411,6 +460,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "https://github.com/fritzy/SleekXMPP"
     },
     {
@@ -419,6 +469,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "https://lab.louiz.org/poezio/slixmpp"
     },
     {
@@ -427,6 +478,7 @@
         "platforms": [
             "Java (Java SE and Android)"
         ],
+        "doap": null,
         "url": "https://www.igniterealtime.org/projects/smack"
     },
     {
@@ -435,6 +487,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "https://github.com/otalk/stanza.io"
     },
     {
@@ -443,6 +496,7 @@
         "platforms": [
             "Java"
         ],
+        "doap": null,
         "url": "https://swift.im/swiften.html"
     },
     {
@@ -451,6 +505,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "http://strophe.im/strophejs"
     },
     {
@@ -459,6 +514,7 @@
         "platforms": [
             "Objective-J"
         ],
+        "doap": null,
         "url": "https://github.com/ArchipelProject/StropheCappuccino"
     },
     {
@@ -467,6 +523,7 @@
         "platforms": [
             "C++"
         ],
+        "doap": null,
         "url": "https://swift.im/swiften.html"
     },
     {
@@ -477,6 +534,7 @@
             "Google Web Toolkit",
             "Java"
         ],
+        "doap": null,
         "url": "https://tigase.net/content/jaxmpp-library"
     },
     {
@@ -485,6 +543,7 @@
         "platforms": [
             "Swift"
         ],
+        "doap": null,
         "url": "https://tigase.tech/projects/tigase-swift"
     },
     {
@@ -493,6 +552,7 @@
         "platforms": [
             "Java"
         ],
+        "doap": null,
         "url": "https://www.igniterealtime.org/projects/tinder/"
     },
     {
@@ -501,6 +561,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "http://twistedmatrix.com"
     },
     {
@@ -509,6 +570,7 @@
         "platforms": [
             "C++"
         ],
+        "doap": null,
         "url": "https://github.com/rpavlik/txmpp"
     },
     {
@@ -517,6 +579,7 @@
         "platforms": [
             "C#"
         ],
+        "doap": null,
         "url": "https://github.com/ubiety/xmpp"
     },
     {
@@ -525,6 +588,7 @@
         "platforms": [
             "Lua"
         ],
+        "doap": null,
         "url": "http://www.matthewwild.co.uk/projects/verse/home"
     },
     {
@@ -535,6 +599,7 @@
             ".NET Standard",
             "C#"
         ],
+        "doap": null,
         "url": "https://waher.se/IoTGateway/Libraries.md#networking"
     },
     {
@@ -544,6 +609,7 @@
             "ActionScript",
             "Flash"
         ],
+        "doap": null,
         "url": "http://igniterealtime.org"
     },
     {
@@ -552,6 +618,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "https://github.com/xmpp-ftw"
     },
     {
@@ -560,6 +627,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "http://code.google.com"
     },
     {
@@ -568,6 +636,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "http://xmppjs.org"
     },
     {
@@ -576,6 +645,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "http://xmpp4js.sourceforge.net/"
     },
     {
@@ -584,6 +654,7 @@
         "platforms": [
             "Ruby"
         ],
+        "doap": null,
         "url": "https://xmpp4r.github.io/"
     },
     {
@@ -592,6 +663,7 @@
         "platforms": [
             "Ruby"
         ],
+        "doap": null,
         "url": "http://code.google.com"
     },
     {
@@ -600,6 +672,7 @@
         "platforms": [
             "Objective C"
         ],
+        "doap": null,
         "url": "http://github.com"
     },
     {
@@ -608,6 +681,7 @@
         "platforms": [
             "PHP"
         ],
+        "doap": null,
         "url": "https://github.com/BirknerAlex/XMPPHP"
     },
     {
@@ -616,6 +690,7 @@
         "platforms": [
             "Python"
         ],
+        "doap": null,
         "url": "http://xmpppy.sourceforge.net"
     },
     {
@@ -624,6 +699,7 @@
         "platforms": [
             "JavaScript"
         ],
+        "doap": null,
         "url": "http://ivan.vucica.net"
     }
 ]

--- a/data/lint-list.py
+++ b/data/lint-list.py
@@ -10,6 +10,7 @@ VALID_ENTRY_KEYS = {
     "platforms",
     "name",
     "last_renewed",
+    "doap",
     "url",
 }
 

--- a/data/servers.json
+++ b/data/servers.json
@@ -6,6 +6,7 @@
             "Linux",
             "Windows"
         ],
+        "doap": null,
         "url": "https://mina.apache.org/vysper-project"
     },
     {
@@ -17,6 +18,7 @@
             "Solaris",
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.astrachat.com/"
     },
     {
@@ -25,6 +27,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "http://citadel.org/doku.php"
     },
     {
@@ -35,6 +38,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.communigate.com"
     },
     {
@@ -43,6 +47,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "http://coversant.com"
     },
     {
@@ -51,6 +56,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "https://danga.com"
     },
     {
@@ -61,6 +67,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.ejabberd.im"
     },
     {
@@ -70,6 +77,7 @@
             "Linux",
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.icewarp.com"
     },
     {
@@ -78,6 +86,7 @@
         "platforms": [
             "macOS"
         ],
+        "doap": null,
         "url": "https://www.apple.com"
     },
     {
@@ -86,6 +95,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "https://rawsontetley.org/proj_inetdxtra.html"
     },
     {
@@ -94,6 +104,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "https://waher.se/Broker.md"
     },
     {
@@ -103,6 +114,7 @@
             "Linux",
             "Windows"
         ],
+        "doap": null,
         "url": "https://isode.com/products/m-link.html"
     },
     {
@@ -113,6 +125,7 @@
             "Solaris",
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.cisco.com"
     },
     {
@@ -121,6 +134,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "http://jabberd.org"
     },
     {
@@ -132,6 +146,7 @@
             "Solaris",
             "Windows"
         ],
+        "doap": null,
         "url": "https://jabberd2.org"
     },
     {
@@ -141,6 +156,7 @@
             "Linux",
             "macOS"
         ],
+        "doap": null,
         "url": "https://github.com/ortuman/jackal"
     },
     {
@@ -150,6 +166,7 @@
             "Linux",
             "Windows"
         ],
+        "doap": null,
         "url": "http://j-livesupport.com"
     },
     {
@@ -158,6 +175,7 @@
         "platforms": [
             "Windows"
         ],
+        "doap": null,
         "url": "http://www.kwickserver.info/cms/"
     },
     {
@@ -166,6 +184,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "https://metronome.im"
     },
     {
@@ -175,6 +194,7 @@
             "Linux",
             "macOS"
         ],
+        "doap": null,
         "url": "https://www.erlang-solutions.com/products/mongooseim.html"
     },
     {
@@ -186,6 +206,7 @@
             "Solaris",
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.igniterealtime.org/projects/openfire/"
     },
     {
@@ -196,6 +217,7 @@
             "Solaris",
             "Windows"
         ],
+        "doap": null,
         "url": "https://www.oracle.com/index.html"
     },
     {
@@ -206,6 +228,7 @@
             "Linux",
             "macOS"
         ],
+        "doap": null,
         "url": "http://prosody.im"
     },
     {
@@ -216,6 +239,7 @@
             "macOS",
             "Windows"
         ],
+        "doap": null,
         "url": "http://psyced.org"
     },
     {
@@ -224,6 +248,7 @@
         "platforms": [
             "Linux"
         ],
+        "doap": null,
         "url": "http://siemens-enterprise.com"
     },
     {
@@ -235,6 +260,7 @@
             "Solaris",
             "Windows"
         ],
+        "doap": null,
         "url": "https://tigase.net/content/tigase-xmpp-server"
     },
     {
@@ -244,6 +270,7 @@
             "Linux",
             "macOS"
         ],
+        "doap": null,
         "url": "https://www.getvines.com"
     },
     {
@@ -254,6 +281,7 @@
             "macOS",
             "Solaris"
         ],
+        "doap": null,
         "url": "https://wokkel.ik.nu"
     }
 ]


### PR DESCRIPTION
I originally introduced my DOAP proposal at standards@ about two years ago: https://mail.jabber.org/pipermail/standards/2017-August/033123.html

This semantic web format describes a project, I extended it with information about XEP support, most relevant to XMPP software. All providers I know of are using its XML serialisation, but other serialisations exist such as Turtle or JSON-LD, they only need support in the triple parsing library used.

I’ve written an implementation in Python, attached in this pull request, as well as a JavaScript one which can be tested here: https://linkmauve.fr/extensions/xep-0048.xml

The Python one imports all of the DOAP information to Pelican, but doesn’t do anything with it yet. It would be nice to store it locally on the server to avoid remote calls at other times than server creation. It would also be useful to generate a per-XEP JSON file or similar, containing only the information they need to render.

I would welcome a better solution than modifying the DOM from JavaScript for XEP integration, but my attempts with using XSLT with XInclude didn’t reach anything usable.

This could be used to implement #585 in the future.