### PR TITLE
Update Travis to Python 3.7 from 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ notifications:
   email: false
 python:
   - 2.7
-  - 3.3
+  - 3.7
 install:
 - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install pelican==3.3 ghp-import markdown; fi
 script:
 - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/dist-packages; fi
 - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then make html; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then ./data/lint-list.py clients.json; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then ./data/lint-list.py servers.json; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then ./data/lint-list.py libraries.json; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then ./data/lint-list.py clients.json; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then ./data/lint-list.py servers.json; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then ./data/lint-list.py libraries.json; fi


### PR DESCRIPTION
3.3 has been EoL for two years now, with the release of 3.3.7 on Sept. 19, 2017: https://www.python.org/downloads/release/python-337/

The image having been removed from whichever Docker repository we’re using, let’s switch to the latest version instead, to let the CI work again.