### PR TITLE
Use python 3.6 for linting tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
   email: false
 python:
   - 2.7
-  - 3.3
+  - 3.6
 install:
 - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install pelican==3.3 ghp-import markdown; fi
 script:


### PR DESCRIPTION
Python 3.3 isn’t found anymore, and Python 3.7 is tricky with travis.