### PR TITLE
One more "H"

### DIFF
--- a/content/posts/newsletter/2019-09-03.md
+++ b/content/posts/newsletter/2019-09-03.md
@@ -65,7 +65,7 @@ Jérôme "Goffi" Poisson has announced [SàT PubSub 0.3.0](https://www.goffi.org
 
 ### Clients
 
-[Kaidan 0.4.0](https://www.kaidan.im/2019/07/08/kaidan-0.4.0/) and [0.4.1](ttps://www.kaidan.im//2019/07/16/kaidan-0.4.1/) have been released, and is available to download on Linux, Windows, and macOS (and experimental Android and Ubuntu Touch).
+[Kaidan 0.4.0](https://www.kaidan.im/2019/07/08/kaidan-0.4.0/) and [0.4.1](https://www.kaidan.im//2019/07/16/kaidan-0.4.1/) have been released, and is available to download on Linux, Windows, and macOS (and experimental Android and Ubuntu Touch).
 
 Jérôme "Goffi" Poisson has released [Salut à Toi v0.7 « La Commune »](https://www.goffi.org/b/N29CuUQS4U4TK36JFuTQ5Q/salut-commune) with tons of changes (and writes regular [SàT progress notes](https://www.goffi.org/b/Gjm7Z5AUt4xh8gciV6wWSe/progress-note)).
 


### PR DESCRIPTION
Note for self, later: it is "https" not "ttps".

https://twitter.com/vascorsd/status/1169200427373670400

> You got a broken link at the kaidan 0.4.1 release.
