### PR TITLE
Please add txxmpp to clients.json

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -647,5 +647,13 @@
             "iOS"
         ],
         "url": "https://zom.im/"
+    },
+    {
+        "last_renewed": null
+        "name": "txmmp",
+        "platforms": [
+            "Unix" 
+        ],
+        "url": "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg-doc.git;a=blob;f=tools/txxmpp.c"
     }
 ]

--- a/data/clients.json
+++ b/data/clients.json
@@ -650,7 +650,7 @@
     },
     {
         "last_renewed": null,
-        "name": "txmmp",
+        "name": "txxmpp",
         "platforms": [
             "Unix" 
         ],

--- a/data/clients.json
+++ b/data/clients.json
@@ -649,7 +649,7 @@
         "url": "https://zom.im/"
     },
     {
-        "last_renewed": null
+        "last_renewed": null,
         "name": "txmmp",
         "platforms": [
             "Unix" 


### PR DESCRIPTION
Due to missing perl libraries in newer Debian versions and other problems with sendxmpp I wrote new new tool named txxmpp.c based on the widely available strophe library.  We use it to push commit announcements to the gnupg-devel MUC.  It is a plain and simple tool with all instructions in the help output.  I am not sure whether it fits into the client list but I have not seen a better place, yet.