### PR TITLE
Update profanity website

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -402,7 +402,7 @@
             "macOS",
             "Windows"
         ],
-        "url": "http://profanity.im"
+        "url": "https://profanity-im.github.io/"
     },
     {
         "last_renewed": "2019-07-16T20:29:28",


### PR DESCRIPTION
Profanitys website moved from profanity.im to https://profanity-im.github.io/.
Right now there is a forwarding set up, but they are considering to ditch
that domain.