### PR TITLE
Update Python version to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,17 @@ notifications:
 
 jobs:
   include:
-  - python: 2.7
+  - python: 3.8
     name: "Website Build"
-  - python: 3.7
+  - python: 3.8
     name: "Data Linting"
 
 install:
-- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install pelican==3.3 ghp-import markdown; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.8 ]]; then pip install pelican==3.3 ghp-import markdown; fi
 
 script:
-- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/dist-packages; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then make html; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then ./data/lint-list.py clients.json; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then ./data/lint-list.py servers.json; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then ./data/lint-list.py libraries.json; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.8 ]]; then export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.8/dist-packages; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.8 ]]; then make html; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.8 ]]; then ./data/lint-list.py clients.json; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.8 ]]; then ./data/lint-list.py servers.json; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.8 ]]; then ./data/lint-list.py libraries.json; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get install -y python-pip git nginx && pip install pelican==3.3 markdown
 WORKDIR /var/tmp/src/xmpp.org
 COPY . /var/tmp/src/xmpp.org
 RUN cd /var/tmp/src/xmpp.org && make publish && cp -prv output/* /var/www/html/
+RUN chmod -R +r /var/www/html/
 COPY deploy/xsf.conf /etc/nginx/sites-available/default
 
 EXPOSE 80

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ ifeq ($(TRAVIS_PULL_REQUEST), false)
 	curl -o /tmp/xep-images/xmpp.pdf       https://xmpp.org/images/xmpp.pdf
 	git clone https://github.com/xsf/xeps /tmp/xeps
 	git clone https://github.com/xsf/xsf-tools /tmp/xsf-tools
-	export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/dist-packages/
+	export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.8/dist-packages/
 	/tmp/xsf-tools/build.py -d -x /tmp/xeps -o /home/travis/build/xsf/xmpp.org/output/extensions --imagespath /tmp/xep-images
 	@git push -fq https://${GH_TOKEN}@github.com/$(TRAVIS_REPO_SLUG).git gh-pages > /dev/null
 endif


### PR DESCRIPTION
The website was still built under Python 2.7, which is due for EOL in
less than three months.