### PR TITLE
update-entry: Add support for passing the DOAP URL as argument

### DIFF
--- a/data/README.rst
+++ b/data/README.rst
@@ -46,7 +46,7 @@ Updating information
 
 When asking the tool for ``--help``, you will notice that it supports a few other options too::
 
-  usage: update-entry.py [-h] [--rename NAME] [--set-url URL]
+  usage: update-entry.py [-h] [--rename NAME] [--set-url URL] [--set-doap URL]
                          [--set-platforms PLATFORM [PLATFORM ...]]
                          [--no-renewal] [--no-ask]
                          JSONFILE [NAME]
@@ -61,6 +61,7 @@ When asking the tool for ``--help``, you will notice that it supports a few othe
     -h, --help            show this help message and exit
     --rename NAME         Rename the project
     --set-url URL         Change the URL of the project
+    --set-doap URL        Change the URL of the project DOAP file
     --set-platforms PLATFORM [PLATFORM ...]
                           Change the contents of the last column
     --no-renewal

--- a/data/update-entry.py
+++ b/data/update-entry.py
@@ -59,6 +59,14 @@ def main():
     )
 
     parser.add_argument(
+        "--set-doap",
+        dest="new_doap",
+        metavar="URL",
+        default=None,
+        help="Change the URL of the project DOAP file",
+    )
+
+    parser.add_argument(
         "--set-platforms",
         dest="new_platforms",
         metavar="PLATFORM",
@@ -136,6 +144,9 @@ def main():
 
     if args.new_url is not None:
         item["url"] = args.new_url or None
+
+    if args.new_doap is not None:
+        item["doap"] = args.new_doap or None
 
     if args.new_platforms is not None:
         item["platforms"] = list(set(


### PR DESCRIPTION
Lets you `./update-entry.py --set-doap https://my-project.example/doap.rdf things.json "My Project"`

