### PR TITLE
Add mellium.im/xmpp Go library

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -371,6 +371,15 @@
     },
     {
         "doap": null,
+        "last_renewed": "2020-03-29T00:00:00",
+        "name": "Mellium",
+        "platforms": [
+            "Go"
+        ],
+        "url": "https://mellium.im/code"
+    },
+    {
+        "doap": null,
         "last_renewed": null,
         "name": "net::XMPP",
         "platforms": [


### PR DESCRIPTION
Adding a link to the [`mellium.im/xmpp`](https://pkg.go.dev/mellium.im/xmpp?tab=doc) library in Go.