### PR TITLE
Remove usage of jQuery in the extension page

### DIFF
--- a/xmpp.org-theme/static/js/extensions-table.js
+++ b/xmpp.org-theme/static/js/extensions-table.js
@@ -1,0 +1,22 @@
+'use strict';
+
+window.addEventListener("load", function() {
+  const checkboxes = document.querySelectorAll("#status-selector > input");
+  const show_hide = function(checkbox) {
+    const xep_status = checkbox.getAttribute("name");
+    const relevant_xeps = document.querySelectorAll(".XEP-" + xep_status);
+    relevant_xeps.forEach(function(xep) {
+      // TODO: add an animation maybe.
+      xep.hidden = !checkbox.checked;
+    });
+    checkbox.addEventListener("click", function(event) {
+      show_hide(event.target);
+    });
+  };
+  checkboxes.forEach(show_hide);
+
+  const jsSupport = document.querySelectorAll(".jsSupport");
+  jsSupport.forEach(function(elem) {
+    elem.classList.remove("jsSupport");
+  });
+});

--- a/xmpp.org-theme/templates/extensions.html
+++ b/xmpp.org-theme/templates/extensions.html
@@ -6,9 +6,12 @@
     margin-left: 5%;
     margin-right: 5%;
   }
+  .jsSupport {
+    display: none;
+  }
 </style>
-<script src='/scripts/sorttable.js' type='text/javascript'></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js" type="text/javascript" ></script>
+<script src="/scripts/sorttable.js" type="text/javascript"></script>
+<script src="/js/extensions-table.js" type="text/javascript"></script>
 {% endblock %}
 
 {% set active_page_url = page.url|replace(" ", "") %}
@@ -22,27 +25,6 @@
   {{ page.content }}
 
 <form action="#">
-  <script type="text/javascript" charset="utf-8">
-   $(document).ready(function(){
-       $("p#status-selector > input").click(function(event){
-           var xep_status = $(this).attr("name");
-           if (this.checked) {
-               $(".XEP-" + xep_status).fadeIn("normal");
-           } else {
-               $(".XEP-" + xep_status).fadeOut("normal");
-           }
-       });
-       jQuery.each($("p#status-selector > input"), function() {
-           var xep_status = $(this).attr("name");
-           if (this.checked) {
-               $(".XEP-" + xep_status).show();
-           } else {
-               $(".XEP-" + xep_status).hide();
-           }
-       });
-       $(".jsSupport").fadeIn("normal");
-   });
-  </script>
   <p id="status-selector" class="jsSupport">
     <input type="checkbox" id="Active" name="Active" checked="checked" /><label for="Active">Active</label>
     <input type="checkbox" id="Deferred" name="Deferred" /><label for="Deferred">Deferred</label>


### PR DESCRIPTION
This disables fade-in and fade-out when adding or removing a set of XEPs, if anyone cares this probably should be implemented using CSS animations.

Fixes #694.