### PR TITLE
Link to xmpp.work

### DIFF
--- a/xmpp.org-theme/templates/top_menu.html
+++ b/xmpp.org-theme/templates/top_menu.html
@@ -40,19 +40,20 @@
             </a>
           </li>
           {% endfor %}
+          {% if page.menu_name == "Community" %}
+          <li> <a href="https://xmpp.work/all-listings" target="_blank" rel="noopener"> Service Providers </a> </li>
+          {% endif %}
         </ul>
         {% endif %}
       </li>
       <li class="divider"></li>
       {% endfor %}
-      <li
-        {% if active_page == "blog" %}
-        class="active"
-        {% endif %}
-       >
-        <a href="{{ SITE_URL }}/blog.html">
-          XMPP Blog
-        </a>
+      <li {% if active_page == "blog" %} class="active" {% endif %} >
+        <a href="{{ SITE_URL }}/blog.html">Blog</a>
+      </li>
+      <li class="divider"></li>
+      <li {% if active_page == "blog" %} class="active" {% endif %} >
+        <a href="https://xmpp.work" target="_blank" rel="noopener">Jobs</a>
       </li>
       <li class="divider"></li>
     </ul>


### PR DESCRIPTION
Adds two links.

A top-level navigation link "Jobs" to https://xmpp.work and a link under
the "Community" dropdown labeled "Service Providers" which links to
https://xmpp.work/all-listings which lists XMPP service providers.

![Screenshot from 2020-06-16 15-47-14](https://user-images.githubusercontent.com/683911/84783596-bd83e580-afe9-11ea-89e0-69e78ca6f5ae.png)
