### PR TITLE
Pelican: Fix usage of PAGES variable

### DIFF
--- a/xmpp.org-theme/templates/footer.html
+++ b/xmpp.org-theme/templates/footer.html
@@ -18,7 +18,7 @@
           Home
         </a>
       </li>
-      {% for page in PAGES|sort(attribute='footer_order') if page.footer_show|default("false") == "left" %}
+      {% for page in pages|sort(attribute='footer_order') if page.footer_show|default("false") == "left" %}
       <li>
         <a href="{{ SITE_URL }}/{{ page.url }}">
           {{ page.menu_name|default(page.title) }}
@@ -32,7 +32,7 @@
           XMPP Blog
         </a>
       </li>
-      {% for page in PAGES|sort(attribute='footer_order') if page.footer_show|default("false") == "right" %}
+      {% for page in pages|sort(attribute='footer_order') if page.footer_show|default("false") == "right" %}
       <li>
         <a href="{{ SITE_URL }}/{{ page.url }}">
           {{ page.menu_name|default(page.title) }}

--- a/xmpp.org-theme/templates/page.html
+++ b/xmpp.org-theme/templates/page.html
@@ -15,7 +15,7 @@
   {%   set menu_title = [] %}
   {%   if page.sidebar_menu_title and menu_title.append(page.sidebar_menu_title) %}{% endif %}
   {%   set P_URL = page.inherit_sidebar|default(page.url) %}
-  {%   for sidebar_source in PAGES|selectattr("url", "equalto", P_URL) %}
+  {%   for sidebar_source in pages|selectattr("url", "equalto", P_URL) %}
   {%      if sidebar_source.sidebar_menu_size|default(false) %}
   {%         if menu_title.append(sidebar_source.sidebar_menu_title) %}{% endif %}
   {%         set size = sidebar_source.sidebar_menu_size|int %}

--- a/xmpp.org-theme/templates/top_menu.html
+++ b/xmpp.org-theme/templates/top_menu.html
@@ -12,7 +12,7 @@
   <section class="top-bar-section">
     <ul class="right">
       <li class="divider"></li>
-      {% for page in PAGES|sort(attribute='top_menu_order') if page.top_menu_show|default("false") == "true" %}
+      {% for page in pages|sort(attribute='top_menu_order') if page.top_menu_show|default("false") == "true" %}
       {% set classes = [] %}
       {% if active_page.split("/")[0]|replace(" ", "") == page.url|replace(" ", "") %}
       {%     set classes = classes + ["active",] %}


### PR DESCRIPTION
See: https://docs.getpelican.com/en/stable/faq.html#since-i-upgraded-pelican-my-pages-are-no-longer-rendered

Fixes #506 

~Pelican documentation for v3.3 also lists a lowercase 'pages' variable, so it should work with the currently used Pelican version as well, see https://docs.getpelican.com/en/3.3.0/themes.html#common-variables~

AFAIK we are stuck on Pelican 3.3 because the menu went missing as soon as we tried to update to a newer Pelican version. This PR does not work with Pelican 3.3 (currently used), Pelican needs to be updated to a recent version. I tried with 4.2, and that worked well (menu shown, no issues found). 