### PR TITLE
Fix 'Jobs' being highlighted when viewing 'Blog'

### DIFF
--- a/xmpp.org-theme/templates/top_menu.html
+++ b/xmpp.org-theme/templates/top_menu.html
@@ -52,7 +52,7 @@
         <a href="{{ SITE_URL }}/blog.html">Blog</a>
       </li>
       <li class="divider"></li>
-      <li {% if active_page == "blog" %} class="active" {% endif %} >
+			<li>
         <a href="https://xmpp.work" target="_blank" rel="noopener">Jobs</a>
       </li>
       <li class="divider"></li>


### PR DESCRIPTION
<https://xmpp.org/blog.html>

Before:

![xmpp org-before](https://user-images.githubusercontent.com/197474/92311024-a2ef5600-efb3-11ea-9846-cc25f64bb405.png)
After:

![xmpp org-after](https://user-images.githubusercontent.com/197474/92311027-a71b7380-efb3-11ea-902e-2f425b541d08.png)

Looks like a simple copypaste mistake.