### PR TITLE
Config: Set SITEURL for Feeds

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -6,7 +6,7 @@ import logging
 import json
 
 SITENAME = "XMPP"
-SITE_URL = ""
+SITEURL = "https://xmpp.org"
 TIMEZONE = "Europe/Paris"  #Unused (Pelican complains if you don't provide it)
 DEFAULT_LANG = "en"
 


### PR DESCRIPTION
This adds SITEURL to pelicanconf.py in order to generate feeds correctly (see https://docs.getpelican.com/en/3.4.0/settings.html > SITEURL)

Fixes #718 