### PR TITLE
Add txxmpp to clients.json

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -636,7 +636,7 @@
         "last_renewed": null,
         "name": "txmmp",
         "platforms": [
-            "Unix",
+            "Unix"
         ],
         "url": "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg-doc.git;a=blob;f=tools/txxmpp.c"
     },

--- a/data/clients.json
+++ b/data/clients.json
@@ -633,7 +633,7 @@
     },
     {
         "doap": null,
-        "last_renewed": null,
+        "last_renewed": "2020-12-10T19:00:55",
         "name": "txmmp",
         "platforms": [
             "Unix"

--- a/data/clients.json
+++ b/data/clients.json
@@ -633,6 +633,15 @@
     },
     {
         "doap": null,
+        "last_renewed": null,
+        "name": "txmmp",
+        "platforms": [
+            "Unix",
+        ],
+        "url": "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg-doc.git;a=blob;f=tools/txxmpp.c"
+    },
+    {
+        "doap": null,
         "last_renewed": "2020-05-10T16:00:55",
         "name": "UWPX",
         "platforms": [


### PR DESCRIPTION
Quote from Werner Koch @dd9jn:

> Due to missing perl libraries in newer Debian versions and other problems with sendxmpp I wrote new new tool named txxmpp.c based on the widely available strophe library.  We use it to push commit announcements to the gnupg-devel MUC.  It is a plain and simple tool with all instructions in the help output.  I am not sure whether it fits into the client list but I have not seen a better place, yet.

I put this into a new commit hoping this will do the fix! See:
https://github.com/xsf/xmpp.org/pull/612