### PR TITLE
Add a dark variant for the main website

### DIFF
--- a/xmpp.org-theme/static/css/app.css
+++ b/xmpp.org-theme/static/css/app.css
@@ -6,3 +6,28 @@
 li p {
     margin-bottom: 0;
 }
+
+@media (prefers-color-scheme: dark) {
+	body {
+		background-color: #161616;
+		color: #ccc;
+	}
+
+	label {
+		color: #aaa;
+	}
+
+	h1, h2, h3, h4, h5, h6 {
+		color: #aaa;
+	}
+
+	table {
+		background-color: #333;
+		border: 1px solid #444;
+	}
+
+	table > tbody > tr > td, table > thead > tr > th {
+		background-color: #282828;
+		color: #ccc;
+	}
+}


### PR DESCRIPTION
After https://github.com/xsf/xeps/pull/1010 it hurts the eyes to go back to the list, this PR fixes that.

I’ve never managed to get Pelican to build, so this was developed by downloading the rendered HTML file from xmpp.org and modifying it until it looks good, but it doesn’t look like it’ll cause any issue.

Here is how it looks: ![wayland-screenshot-2020-12-29_17-56-57](https://user-images.githubusercontent.com/7755816/103300566-6a123b80-49ff-11eb-91a5-2c6c054086af.jpeg)