### PR TITLE
Update poezio’s DOAP file.

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -434,8 +434,8 @@
         "url": "https://pidgin.im"
     },
     {
-        "doap": "https://lab.louiz.org/poezio/poezio/raw/master/data/doap.xml",
-        "last_renewed": "2020-08-31T10:00:00",
+        "doap": "https://lab.louiz.org/poezio/poezio/-/raw/main/data/doap.xml",
+        "last_renewed": "2021-01-02T19:29:38",
         "name": "Poezio",
         "platforms": [
             "Linux",

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -493,7 +493,7 @@
     },
     {
         "doap": "https://lab.louiz.org/poezio/slixmpp/-/raw/master/doap.xml",
-        "last_renewed": "2020-12-04T19:05:38",
+        "last_renewed": "2021-01-02T19:29:38",
         "name": "Slixmpp",
         "platforms": [
             "Python"


### PR DESCRIPTION
poezio’s main branch changed to main, this also synchronises slixmpp and poezio’s renewal time.