### PR TITLE
Add an @alt to images which didn’t have one

### DIFF
--- a/xmpp.org-theme/templates/footer.html
+++ b/xmpp.org-theme/templates/footer.html
@@ -7,7 +7,7 @@
   </ul>
 </div>
 <div class="footer-github">
-  <p><a href="//github.com/xsf/xmpp.org"><img src="/theme/images/github.svg"></a>This site is organized in the open on GitHub. <a href="//github.com/xsf/xmpp.org">Suggest changes</a>.</p>
+  <p><a href="//github.com/xsf/xmpp.org"><img src="/theme/images/github.svg" alt="GitHub logo"></a>This site is organized in the open on GitHub. <a href="//github.com/xsf/xmpp.org">Suggest changes</a>.</p>
   <p>The xmpp.org domain was generously donated by <a href="http://opendomain.org">OpenDomain.org</a>.</p>
 </div>
 <footer class="top-bar">

--- a/xmpp.org-theme/templates/top_menu.html
+++ b/xmpp.org-theme/templates/top_menu.html
@@ -2,7 +2,7 @@
   <ul class="title-area">
     <li class="name">
       <h1>
-        <a href="{{ SITE_URL }}/"><img src="/theme/images/xmpp-logo.svg" style="display: inline-block; margin: -3px 5px 0 0; width: 30px; "/>{{ SITENAME }}</a>
+        <a href="{{ SITE_URL }}/"><img src="/theme/images/xmpp-logo.svg" alt="XMPP logo" style="display: inline-block; margin: -3px 5px 0 0; width: 30px; "/>{{ SITENAME }}</a>
       </h1>
     </li>
     <li class="toggle-topbar menu-icon">


### PR DESCRIPTION
This can be useful for accessibility tools, or during development to know which image corresponds to that one missing image.