### PR TITLE
Newsletter June: Update XEP section

### DIFF
--- a/content/posts/newsletter/2021-07-05.md
+++ b/content/posts/newsletter/2021-07-05.md
@@ -98,12 +98,19 @@ Developers and other standards experts from around the world collaborate on thes
 
 The XEP development process starts by writing up an idea and submitting it to the XMPP Editor. Within two weeks, the Council decides whether to accept this proposal as an Experimental XEP.
 
--   [XMPP Compliance Suites 2022](https://xmpp.org/extensions/inbox/cs-2022.html)
-    -   This document defines XMPP application categories for different use cases (Core, Web, IM, and Mobile), and specifies the required XEPs that client and server software needs to implement for compliance with the use cases.
+-   [Pre-auth Registration Key Generation and Validation](https://xmpp.org/extensions/inbox/preauth-ibr.html)
+    -   This specification updates XEP-0401 and XEP-0445 by specifying a shared format for the pre-authenticated registration token.
+
+-   [Moved 2.0](https://xmpp.org/extensions/inbox/moved2.html)
+    -   This specification details a way for a user to notify their contacts about an account move.
 
 ### New
 
--   No new XEP this month.
+-   Version 0.1.0 of [XEP-0459](https://xmpp.org/extensions/xep-0459.html) (XMPP Compliance Suites 2022)
+    -   Accepted by vote of Council on 2021-05-26.
+
+-   Version 0.1.0 of [XEP-0458](https://xmpp.org/extensions/xep-0458.html) (Community Code of Conduct)
+    -   Accept as Experimental after unanimous approval by Board of the ProtoXEP draft for discussion within the community.
 
 ### Deferred
 
@@ -113,11 +120,23 @@ If an experimental XEP is not updated for more than twelve months, it will be mo
 
 ### Updated
 
--   Version 0.7.0 of [XEP-0373](https://xmpp.org/extensions/xep-0373.html) (OpenPGP for XMPP)
-    -   Recommend PubSub access model 'open' for public key data node and metadata node. (ps)
+-   Version 0.2.0 of [XEP-0458](https://xmpp.org/extensions/xep-0458.html) (Community Code of Conduct)
+    -   Integrate various comments from various sources (dwd)
 
--   Version 1.3 of [XEP-0013](https://xmpp.org/extensions/xep-0013.html) (Flexible Offline Message Retrieval)
-    -   Deprecate after council vote of 2021-03-31 (XEP Editor (jsc))
+-   Version 0.3 of [XEP-0377](https://xmpp.org/extensions/xep-0377.html) (Spam Reporting)
+    -   Rework based on list feedback. (ssw)
+
+-   Version 0.11 of [XEP-0292](https://xmpp.org/extensions/xep-0292.html) (vCard4 Over XMPP)
+    -   Recommend use of contact bare JIDs for item IDs (ka)
+
+-   Version 1.20.0 of [XEP-0060](https://xmpp.org/extensions/xep-0060.html) (Publish-Subscribe)
+    -   Add integer-or-max datatype to use with Data Forms Validation. (pep)
+
+### Obsoleted
+
+-   Version 1.0.0 of [XEP-0423](https://xmpp.org/extensions/xep-0423.html) (XMPP Compliance Suites 2020)
+    -   Update to Draft as per council vote on 2019/11/07
+    -   Successors are XMPP Compliance Suites 2021 ([XEP-0443](https://xmpp.org/extensions/xep-0443.html)) and 2022 ([XEP-0459](https://xmpp.org/extensions/xep-0459.html))
 
 ### Last Call
 


### PR DESCRIPTION
This updates the XEP section in June's newsletter issue to the correct version. #936 has been merged into the wrong branch by accident.

@Echolon 