### PR TITLE
create a central redirect for 'current Compliance Suite'

### DIFF
--- a/content/extensions.md
+++ b/content/extensions.md
@@ -9,6 +9,6 @@ The core specifications for XMPP are developed at the Internet Engineering Task 
 
 The XMPP Standards Foundation develops extensions to XMPP in its XEP series. This page lists Draft and Final XEPs as well as experimental proposals that are currently under consideration.
 
-Good places for developers to start are the [compliance suites](https://xmpp.org/extensions/xep-0443.html), as well as the [technology overview pages](https://xmpp.org/about-xmpp/technology-overview/).
+Good places for developers to start are the [compliance suites](https://xmpp.org/about/compliance-suites-current), as well as the [technology overview pages](https://xmpp.org/about-xmpp/technology-overview/).
 
 {{< extensions-table >}}

--- a/deploy/xsf.conf
+++ b/deploy/xsf.conf
@@ -26,6 +26,7 @@ server {
         try_files $uri $uri/ $uri.html =404;
     }
 
+    rewrite ^/about/compliance-suites-current$                  /extensions/xep-0443.html;
     rewrite ^/about/ipr-policy$                                 /about/xsf/ipr-policy;
     rewrite ^/about/xsf/xsf-ipr-policy$                         /about/xsf/ipr-policy;
     rewrite ^/xmpp-protocols/xmpp-extensions/submitting-a-xep$  /about/standards-process.html#submitting-a-xep;


### PR DESCRIPTION
It makes some sense to have a central link for the "current" Compliance Suite, that will get updated every year.

We have https://xmpp.org/about/compliance-suites.html as a description of the CS, so having https://xmpp.org/about/compliance-suites-current seemed logical to me.