### PR TITLE
Fixes for the new Hugo based site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xmpp.org
 
-[![Build Status](https://travis-ci.com/xsf/xmpp.org.png?branch=master)](https://travis-ci.com/xsf/xmpp.org)
+[![Build Status](https://app.travis-ci.com/xsf/xmpp.org.svg?branch=master)](https://app.travis-ci.com/xsf/xmpp.org)
 [![Docker Build Status](https://img.shields.io/docker/cloud/build/xmppxsf/xmpp.org)](https://hub.docker.com/r/xmppxsf/xmpp.org/builds/)
 
 Please log any [issues](https://github.com/xsf/xmpp.org/issues/new).
@@ -20,7 +20,7 @@ Please use [xsf@muc.xmpp.org](xmpp:xsf@muc.xmpp.org?join) for discussions about 
 ## Site generation
 
 * Commits to the master branch generate a new build.
-* Builds are visible at [Travis-CI](https://travis-ci.com/xsf/xmpp.org/builds)
+* Builds are visible at [Travis-CI](https://app.travis-ci.com/github/xsf/xmpp.org/builds)
 * Changes will be visible on [xmpp.org](https://xmpp.org) after the next update
 
 ## Software Requirements

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://xmpp.org/"
 contentdir = "content"
 layoutdir = "layouts"
 publishdir = "public"

--- a/content/blog/2021-09-05.md
+++ b/content/blog/2021-09-05.md
@@ -163,15 +163,7 @@ Please share the news via other networks:
 
 Find and place job offers in the [XMPP job board](https://xmpp.work/).
 
-<form style="padding: 10px; text-align:center; margin-bottom: 30px;"
-      action="https://tinyletter.com/xmpp" method="post" target="popupwindow"
-      onsubmit="window.open('https://tinyletter.com/xmpp', 'popupwindow',
-      'scrollbars=yes,width=800,height=600');return true">
-<p><label for="tlemail">Subscribe to receive the next edition in your inbox</label></p>
-<p><input type="text" placeholder="Email address" name="email" id="tlemail" /></p>
-<input type="hidden" value="1" name="embed"/>
-<input type="submit" style="padding: 10px; border-radius: 5%" value="Subscribe" />
-</form>
+{{< newsletter-subscribe >}}
 
 Also check out our [RSS Feed](https://xmpp.org/feeds/all.atom.xml)!
 

--- a/content/software/clients.md
+++ b/content/software/clients.md
@@ -9,6 +9,6 @@ An XMPP client is any software or application that enables you to connect to an 
 
 > Note: The following software was not developed by the XMPP Standards Foundation and has not been formally tested for standards compliance, usability, reliability, or performance.
 
-__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If __you are related to the project__ and spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/tree/master/data/README.rst)
+__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If __you are related to the project__ and spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/tree/master/tools/README.rst)
 
 {{< software-list >}}

--- a/content/software/libraries.md
+++ b/content/software/libraries.md
@@ -8,6 +8,6 @@ Code libraries and tools are available for many different programming languages,
 
 > Note: The following software was not developed by the XMPP Standards Foundation and has not been formally tested for standards compliance, usability, reliability, or performance.
 
-__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If __you are related to the project__ and spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/tree/master/data/README.rst)
+__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If __you are related to the project__ and spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/tree/master/tools/README.rst)
 
 {{< software-list >}}

--- a/content/software/servers.md
+++ b/content/software/servers.md
@@ -8,6 +8,6 @@ An XMPP server provides basic messaging, presence, and XML routing features. Thi
 
 > Note: The following software was not developed by the XMPP Standards Foundation and has not been formally tested for standards compliance, usability, reliability, or performance.
 
-__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If __you are related to the project__ and spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/tree/master/data/README.rst)
+__See something missing?__ Any list of XMPP servers, clients or libraries will, due to the dynamic and evolving nature of the XMPP market, be out of date almost as soon as it’s published. If __you are related to the project__ and spot mistakes, errors or omissions in the table below, please [submit a pull request!](https://github.com/xsf/xmpp.org/tree/master/tools/README.rst)
 
 {{< software-list >}}

--- a/themes/xmpp.org/layouts/_default/rss.xml
+++ b/themes/xmpp.org/layouts/_default/rss.xml
@@ -1,0 +1,39 @@
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" -}}
+	  {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end -}}
+    {{ range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Content | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/themes/xmpp.org/layouts/index.html
+++ b/themes/xmpp.org/layouts/index.html
@@ -26,7 +26,7 @@
         <p>It's a <a href="/about/standards-process">living standard</a>. Engineers actively extend and improve it.</p>
       </div>
       <div class="col text-center feature-home">
-        <p>Millions use <a href="/software/xmpp-software">XMPP software</a> daily to connect to people and services.</p>
+        <p>Millions use <a href="/software">XMPP software</a> daily to connect to people and services.</p>
       </div>
     </div>
 </div>
@@ -49,7 +49,7 @@
       <img class="logo-software" src="/images/logos/android.svg" alt="Android">
     </div>
     <h5 class="text-center">
-      <a href="/software/">Find the tools you need »</a>
+      <a href="/software">Find the tools you need »</a>
     </h5>
  </div>
 {{ end }}

--- a/themes/xmpp.org/layouts/partials/footer.html
+++ b/themes/xmpp.org/layouts/partials/footer.html
@@ -8,7 +8,7 @@
 </div>
 
 <div class="footer-github">
-    <p><a href="https://github.com/xsf/xmpp.org" target="blank_"><img src="/images/logos/github.svg"></a>This site is organized in the open on GitHub. <a href="https://github.com/xsf/xmpp.org" target="blank_">Suggest changes</a>.</p>
+    <p><a href="https://github.com/xsf/xmpp.org" target="blank_"><img src="/images/logos/github.svg" alt="GitHub logo"></a>This site is organized in the open on GitHub. <a href="https://github.com/xsf/xmpp.org" target="blank_">Suggest changes</a>.</p>
     <p>The xmpp.org domain was generously donated by <a href="https://opendomain.org" target="blank_">OpenDomain.org</a>.</p>
 </div>
 
@@ -16,7 +16,7 @@
     <div class="container">
         <div class="row g-4 py-5 row-cols-1 row-cols-sm-4">
             <div class="col d-flex">
-                <img src="/images/logos/xmpp-logo.svg"style="width: 150px;">
+                <img src="/images/logos/xmpp-logo.svg" alt="XMPP logo" style="width: 150px;">
             </div>
             <div class="col d-flex">
                 <ul>

--- a/themes/xmpp.org/layouts/partials/nav.html
+++ b/themes/xmpp.org/layouts/partials/nav.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="{{ .Site.BaseURL | relLangURL }}">
-        <img src="/images/logos/xmpp-logo.svg" class="navbar-logo">
+        <img src="/images/logos/xmpp-logo.svg" alt="XMPP logo" class="navbar-logo">
         {{ .Site.Title }}
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">

--- a/themes/xmpp.org/layouts/partials/post_meta.html
+++ b/themes/xmpp.org/layouts/partials/post_meta.html
@@ -12,14 +12,14 @@
       &nbsp;|&nbsp;
       {{ range $category := .Params.categories }}
         <span class="blog-tags">
-        <a href="{{ $.Site.LanguagePrefix | absURL }}/categories/{{ . | urlize }}/">{{ . }}</a></span>
+        <a href="/categories/{{ . | urlize }}/">{{ . }}</a></span>
       {{ end }}
     {{ end }}
     {{ if .Params.tags }}
       &nbsp;|&nbsp;
       {{ range $tag := .Params.tags }}
         <span class="blog-tags">
-        <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a></span>
+        <a href="/tags/{{ . | urlize }}/">{{ . }}</a></span>
       {{ end }}
     {{ end }}
     {{ if .Site.Params.wordCount }}

--- a/themes/xmpp.org/layouts/partials/sidebar_blog.html
+++ b/themes/xmpp.org/layouts/partials/sidebar_blog.html
@@ -8,7 +8,7 @@
     <h3>Categories</h3>
     <ul>
     {{ range .Site.Taxonomies.categories.ByCount }}
-    <li><a href="/categories/{{ .Name | urlize }}">{{ .Name }}</a> ({{ .Count }})</li>
+    <li><a href="/categories/{{ .Name | urlize }}">{{ .Page.Title }}</a> ({{ .Count }})</li>
     {{ end }}
     </ul>
 </aside>


### PR DESCRIPTION
Fixes some issues found after upgrading xmpp.org to Hugo generated pages:

* Newsletter September 21: Use shortcode for subscription box
* Blog Sidebar: Display category title correctly
* Post Meta: Fix category link
* Software: Fix link to software listing readme
* Frontpage: Fix software link
* RSS: Add custom RSS template (full post content instead of post summary)
* Config: Add https://xmpp.org/ baseURL (hopefully resolves #601 )
* Add @alt to navigation images (obsoletes #868 )
* Readme: Fix Travis-CI badge and links