### PR TITLE
Extensions: List new and recently changed XEPs

### DIFF
--- a/content/extensions.md
+++ b/content/extensions.md
@@ -5,7 +5,24 @@ aliases:
     - "/extensions/index.html"
     - "/protocols/xmpp-extensions/"
 ---
-The core specifications for XMPP are developed at the Internet Engineering Task Force (IETF) - see [RFC 6120](https://datatracker.ietf.org/doc/rfc6120/), [RFC 7590](https://datatracker.ietf.org/doc/rfc7590/), [RFC 6121](https://datatracker.ietf.org/doc/rfc6121/), and [RFC 7622](https://datatracker.ietf.org/doc/rfc7622/) (along with a WebSocket binding defined in [RFC 7395](https://datatracker.ietf.org/doc/rfc7395/)).
+
+## IETF specifications
+
+-   [RFC 6120](https://datatracker.ietf.org/doc/rfc6120/) XMPP Core
+-   [RFC 6121](https://datatracker.ietf.org/doc/rfc6121/) XMPP IM
+-   [RFC 7622](https://datatracker.ietf.org/doc/rfc7622/) XMPP Address Format
+-   [RFC 7590](https://datatracker.ietf.org/doc/rfc7590/) Use of TLS in XMPP
+-   [RFC 7395](https://datatracker.ietf.org/doc/rfc7395/) XMPP over WebSockets
+
+## New XEPs
+
+{{< new-xeps >}}
+
+## Recently updated
+
+{{< updated-xeps >}}
+
+## The whole list
 
 The XMPP Standards Foundation develops extensions to XMPP in its XEP series. This page lists Draft and Final XEPs as well as experimental proposals that are currently under consideration.
 

--- a/content/extensions.md
+++ b/content/extensions.md
@@ -6,7 +6,8 @@ aliases:
     - "/protocols/xmpp-extensions/"
 ---
 
-## IETF specifications
+{{< row >}}
+{{< col header="IETF specifications" >}}
 
 -   [RFC 6120](https://datatracker.ietf.org/doc/rfc6120/) XMPP Core
 -   [RFC 6121](https://datatracker.ietf.org/doc/rfc6121/) XMPP IM
@@ -14,13 +15,16 @@ aliases:
 -   [RFC 7590](https://datatracker.ietf.org/doc/rfc7590/) Use of TLS in XMPP
 -   [RFC 7395](https://datatracker.ietf.org/doc/rfc7395/) XMPP over WebSockets
 
-## New XEPs
+{{< /col >}}
 
+{{< col header="New XEPs" content="shortcode" >}}
 {{< new-xeps >}}
+{{< /col >}}
 
-## Recently updated
-
+{{< col header="Recently updated" content="shortcode" >}}
 {{< updated-xeps >}}
+{{< /col >}}
+{{< /row >}}
 
 ## The whole list
 

--- a/themes/xmpp.org/layouts/shortcodes/col.html
+++ b/themes/xmpp.org/layouts/shortcodes/col.html
@@ -1,0 +1,10 @@
+<div class="col align-items-start">
+{{ if .Get "header" }}
+<h2>{{ .Get "header" }}</h2>
+{{ end }}
+{{ if eq ( .Get "content") "shortcode" }}
+		{{ .Inner }}
+{{ else }}
+		{{ .Inner | markdownify }}
+{{ end }}
+</div>

--- a/themes/xmpp.org/layouts/shortcodes/col.html
+++ b/themes/xmpp.org/layouts/shortcodes/col.html
@@ -1,4 +1,4 @@
-<div class="col align-items-start">
+<div class="col-xl-4 col-md-6">
 {{ if .Get "header" }}
 <h2>{{ .Get "header" }}</h2>
 {{ end }}

--- a/themes/xmpp.org/layouts/shortcodes/new-xeps.html
+++ b/themes/xmpp.org/layouts/shortcodes/new-xeps.html
@@ -1,0 +1,6 @@
+<ul>
+{{ range first 5 (sort .Site.Data.xeplist ".number" "desc") }}
+{{ $number_str := printf "%04g" .number }}
+<li><a href="/extensions/xep-{{ $number_str }}.html">XEP-{{ $number_str }}</a> {{ .title }}</li>
+{{ end }}
+</ul>

--- a/themes/xmpp.org/layouts/shortcodes/row.html
+++ b/themes/xmpp.org/layouts/shortcodes/row.html
@@ -1,0 +1,6 @@
+<div class="container">
+<div class="row">
+{{ .Inner }}
+</div>
+</div>
+

--- a/themes/xmpp.org/layouts/shortcodes/updated-xeps.html
+++ b/themes/xmpp.org/layouts/shortcodes/updated-xeps.html
@@ -1,0 +1,6 @@
+<ul>
+{{ range first 5 (sort .Site.Data.xeplist ".last_updated" "desc") }}
+{{ $number_str := printf "%04g" .number }}
+<li><a href="/extensions/xep-{{ $number_str }}.html">XEP-{{ $number_str }}</a> {{ .title }}</li>
+{{ end }}
+</ul>


### PR DESCRIPTION
Goal is to show new and recently updated XEPs more prominently.

I wanted to make these into three columns (like on [modules.prosody.im](https://modules.prosody.im/)), but I could not get nested shortcodes to work.

![image](https://user-images.githubusercontent.com/197474/133892865-513383d9-cdb7-4d70-9c7c-e1da3689644c.png)
