### PR TITLE
CSS: Widen the XEP table

### DIFF
--- a/themes/xmpp.org/static/css/style.css
+++ b/themes/xmpp.org/static/css/style.css
@@ -318,6 +318,9 @@ ul.share {
 .xeplist input {
     margin-right: 4px;
 }
+table#xeplist {
+	width: 100%;
+}
 
 /* Dark theme */
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Looked unbalanced.

Before:

![image](https://user-images.githubusercontent.com/197474/133927670-95240892-87d6-4878-9aea-741dac15daee.png)

After:

![image](https://user-images.githubusercontent.com/197474/133927687-377d3ec9-8c38-4f46-8bdd-cc01452dfcc6.png)
