### PR TITLE
Deduplicate use of subtitle in theme

### DIFF
--- a/themes/xmpp.org/layouts/index.html
+++ b/themes/xmpp.org/layouts/index.html
@@ -8,7 +8,7 @@
 {{ end }}
 <div class="header-home py-5 text-center">
     <div class="hero">
-      <h1>The universal messaging standard</h1>
+      <h1>{{ .Param "subtitle" }}</h1>
       <h3>Tried and tested. Independent. Privacy-focused.</h3>
       <a type="button" class="btn btn-secondary btn-lg px-4" href="/getting-started">Get Started</a>
     </div>

--- a/themes/xmpp.org/layouts/partials/head.html
+++ b/themes/xmpp.org/layouts/partials/head.html
@@ -6,7 +6,11 @@
     <link rel="stylesheet" type="text/css" href="{{ "fonts/font.css" | absURL }}">
     <link rel="stylesheet" type="text/css" href="{{ "fontawesome/css/all.min.css" | absURL }}">
     <link rel="me" href="https://fosstodon.org/@xmpp">
-    {{ $title := print .Site.Title " | " .Title }}
-    {{ if .IsHome }}{{ $title = print .Site.Title " | The universal messaging standard" }}{{ end }}
-    <title>{{ $title }}</title>
+    <title>
+      {{- if .IsHome }}
+      {{- printf "%s | %s" .Site.Title (.Param "subtitle") }}
+      {{- else }}
+      {{- printf "%s | %s" .Site.Title .Title }}
+      {{- end }}
+    </title>
 </head>


### PR DESCRIPTION
Previously the subtitle was used several times in the theme. This mixes
content and theming so instead pull the subtitle from the config so that
if it ever changes the change is reflected everywhere.