### PR TITLE
Force a redirect to compliance suite XEP

### DIFF
--- a/deploy/xsf.conf
+++ b/deploy/xsf.conf
@@ -26,7 +26,7 @@ server {
         try_files $uri $uri/ $uri.html =404;
     }
 
-    rewrite ^/about/compliance-suites-current$                  /extensions/xep-0443.html;
+    rewrite ^/about/compliance-suites-current$                  /extensions/xep-0443.html redirect;
     rewrite ^/about/ipr-policy$                                 /about/xsf/ipr-policy;
     rewrite ^/about/xsf/xsf-ipr-policy$                         /about/xsf/ipr-policy;
     rewrite ^/xmpp-protocols/xmpp-extensions/submitting-a-xep$  /about/standards-process.html#submitting-a-xep;


### PR DESCRIPTION
The target resource (xep-0443.html) is not served by the same nginx instance that serves the rest of the website (/extensions is managed and deployed separately as part of the xsf/xeps repo). Apparently nginx shortcuts and returns a 404 instead of a redirect when it can't find the target file.

Using a full https:// URL or appending the 'redirect' flag is enough to fix this. I opted for the latter.

This change is already tested and deployed 😇