### PR TITLE
Docker: Add development variant for local builds

### DIFF
--- a/DockerfileDev
+++ b/DockerfileDev
@@ -1,0 +1,32 @@
+# Dockerfile to build a docker image from XSF/xmpp.org Master for development purposes
+#
+# Dave Cridland <dave.cridland@surevine.com>
+# Copyright 2017 Surevine Ltd
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+FROM debian:bullseye
+MAINTAINER Dave Cridland <dave.cridland@surevine.com>
+
+# Set environment variables
+ENV DEBIAN_FRONTEND noninteractive
+
+# Update system
+RUN apt-get update && apt-get dist-upgrade -y && apt-get autoremove -y && apt-get clean
+
+# Install dependencies.
+RUN apt-get install -y hugo python3 python3-pip && pip3 install requests
+
+# Build and copy in place.
+WORKDIR /var/tmp/src/xmpp.org
+COPY . /var/tmp/src/xmpp.org
+RUN cd /var/tmp/src/xmpp.org && make prepare_docker
+
+FROM nginx
+COPY deploy/xsf.conf /etc/nginx/conf.d/default.conf
+COPY --from=0 /var/tmp/src/xmpp.org/public/ /var/www/html/

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ help:
 	@echo '   make clean                       remove the generated files         '
 	@echo '   make publish                     generate using production settings '
 	@echo '   make serve                       serve site at http://localhost:1313'
+	@echo '   make prepare_docker              prepare site for serving via docker'
 	@echo '   make ssh_upload                  upload the web site via SSH        '
 	@echo '   make rsync_upload                upload the web site via rsync+ssh  '
 	@echo '   make dropbox_upload              upload the web site via Dropbox    '
@@ -49,7 +50,12 @@ clean:
 serve:
 	$(PY) $(TOOLSDIR)/prepare_xep_list.py
 	$(HUGO) version
-	$(HUGO) server --bind=0.0.0.0
+	$(HUGO) server --bind=0.0.0.0 --baseURL="http://localhost/"
+
+prepare_docker:
+	$(PY) $(TOOLSDIR)/prepare_xep_list.py
+	$(HUGO) version
+	$(HUGO) --baseURL="http://localhost/"
 
 publish:
 	$(PY) $(TOOLSDIR)/prepare_xep_list.py

--- a/MakefileDocker
+++ b/MakefileDocker
@@ -1,9 +1,9 @@
 #
-# Build a docker image to build the website
+# Build a docker image to build the website locally (for development)
 #
 
 all:
-	docker build -t xmpp-org/latest .
+	docker build -t xmpp-dockerdev -f ./DockerfileDev .
 
 serve:
-	docker run -p 80:80 -t -i xmpp-org/latest
+	docker run -p 80:80 -t -i xmpp-dockerdev


### PR DESCRIPTION
This adds a development variant of `Dockerfile`, named `DockerfileDev`. `DockerfileDev` employs the new `make prepare_docker`, which builds the website locally while using "http://localhost" for Hugo's baseURL. This is needed for assets (CSS, JS) to be loaded correctly when running the website locally.

`make -f MakefileDocker` will use `DockerfileDev` for building the docker image locally, which will be run when using `make -f MakefileDocker serve`.