### PR TITLE
Include applicant critera for fiscal hosting

### DIFF
--- a/content/community/fiscalhost.md
+++ b/content/community/fiscalhost.md
@@ -6,20 +6,62 @@ Url: community/fiscalhost
 The XSF is a U.S. 501(c)(3) organization.
 It sometimes acts as a fiscal host for open source projects related to XMPP.
 
-The XSF may choose to accept organizations at the discretion of the board,
-treasurer, or anyone else to whom the board has delegated this authority.
-Projects must be open source with source code, documentation, resources, and
-other non-code assets released using an OSI approved license
-(https://opensource.org/licenses/alphabetical) or a Creative Commons license
-(https://creativecommons.org/licenses/).
-Trademarks will continue to be held by the project and the XSF will not take
-ownership of any project assets.
-The XSF will not charge a fee for this service.
+The XSF (the "sponsor") may choose to accept sponsored organizations
+("organizations") at the discretion of the board of directors (the "board") or
+treasurer of the XSF, or anyone else to whom the board has delegated this
+authority.
+
+Applicants for fiscal hosting must meet the following criteria (exceptions can
+be made at the discretion of the board):
+
+- An applicant that involves code must be open source with source code,
+  documentation, resources, and other non-code assets released using an [OSI
+  approved license][OSI] or a [Creative Commons license][CC].
+- Meetups and recurring events must demonstrate that they have successfully
+  hosted at least two of the event in the past.
+- Applicants must be in line with the XSF's charitable mission.
+- Applicants must be able to demonstrate an active community (ie. chat rooms,
+  mailing lists, issue trackers, multiple committers, etc.)
+
+The following rules must be observed after being accepted and must be agreed to
+before being accepted:
+
+- The sponsored organization must not use funds to participate in or intervene
+  in any political campaign or lobbying group that would be forbidden under the
+  XSF's 501(c)(3) status.
+- The sponsored organization must not take any other action inconsistent with
+  USC section 501(c)(3).
+- The sponsored organization agree to notify the XSF before changing their
+  mission or direction so that the mission can be re-evaluated in terms of the
+  XSF's 501(c)(3) status.
+- The sponsored organization must not enter into any legal agreement with a
+  third party such as venues, contractors, etc. without explicit written
+  permission from the XSF board.
+  Such agreements are legally between the third party and the sponsor.
+- The sponsored organization hosted by the XSF must not engage in fund raising
+  in the real world (ie. not online) unless they first ask permission from the
+  sponsor and receive permission from the board or treasurer.
+- If the sponsored organization fundraises or otherwise receives funds outside
+  of the Open Collective platform they must transfer those funds to the sponsor
+  immediately.
+- The sponsored organization will not hold any funds outside of the sponsor's
+  account at any time, nor will the sponsored organization have multiple
+  sponsors.
+
+Trademarks and other intellectual property (IP) will continue to be held by the
+project and the sponsor will not take ownership of any project assets.
+The sponsor will not charge a fee for this service.
 
 To apply for fiscal sponsorship, fill out the form on Open Collective.
 Please link your projects home page (if applicable) and public source repository
-where the license is clearly visible.
+where the license is clearly visible as well as any other contributing resource
+(ie. a chat room where the community requirement can be verified).
 Please disclose any other corporate or fiscal affiliations.
+By applying you are agreeing to follow the rules outlined on this page if
+accepted.
 
 
 https://opencollective.com/xmpp
+
+[OSI]: https://opensource.org/licenses/alphabetical
+[CC]: https://creativecommons.org/licenses/


### PR DESCRIPTION
The board has been unable to accept or deny our current fiscal hosting applicant because they haven't been able to meet and decide on what criteria to use to evaluate them. I've put this list together as a starting point that I hope will make it easier for them.