### PR TITLE
Add default blog post parameters

### DIFF
--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,0 +1,8 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+# author: you
+# categories: ["Newsletter"]
+draft: true
+---
+


### PR DESCRIPTION
This makes it easier for users to know what options they can fill out
when starting a new blog post using "hugo new". Other options that should be filled out by users writing blog posts can be added later.