### PR TITLE
Config: allow unsafe rendering of raw HTML

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -24,3 +24,6 @@ enableEmoji = true
 
 [permalinks]
   blog = "/:year/:month/:title/"
+
+[markup.goldmark.renderer]
+unsafe = true


### PR DESCRIPTION
This is needed for some pages (e.g. old Summits) that use `<table>` and
other raw elements.

Affected page example:

https://xmpp.org/2010/08/xmpp-summit-4/ (scroll down to "**Room shares and room reservations for XSF members.**")

Current rendering:

![image](https://user-images.githubusercontent.com/165635/138130592-011fa890-8738-442c-a6c5-80223b284cd7.png)

Expected / fixed rendering:

![image](https://user-images.githubusercontent.com/165635/138130788-be9afa0e-9f6a-4681-80b1-e411a6709811.png)
