### PR TITLE
Style: add styling for blockquotes

### DIFF
--- a/themes/xmpp.org/assets/css/style.css
+++ b/themes/xmpp.org/assets/css/style.css
@@ -16,6 +16,14 @@ li,
 blockquote {
     font-family: "Merriweather", serif !important;
 }
+blockquote {
+    background: #f5f5f5;
+    border-left: 10px solid #ccc;
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.5rem 0.5rem 1rem;
+}
+/* remove margin from last paragraph in blockquote */
+blockquote > :last-child { margin-bottom: 0 !important; }
 a {
     color: #008cba;
     line-height: inherit;


### PR DESCRIPTION
This adds a nicer rendering for `<blockquote>` elements.

Currently (taken from [Myths](https://xmpp.org/about/myths/):

![image](https://user-images.githubusercontent.com/165635/138131075-1392f1aa-3015-4c12-9592-ee133fc36662.png)

Fixed rendering:

![image](https://user-images.githubusercontent.com/165635/138131140-2b881d9c-f98e-4ded-970c-7087ce912b47.png)
