### PR TITLE
Add office hours signup form

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -144,6 +144,11 @@
     parent = "community"
     weight = 8
 [[main]]
+    name = "Office Hours"
+    url = "community/officehours"
+    parent = "community"
+    weight = 9
+[[main]]
     name = "Getting Started"
     url = "/getting-started"
     weight = 5

--- a/content/community/officehours.md
+++ b/content/community/officehours.md
@@ -1,0 +1,15 @@
+---
+Title: Office Hours
+Url: community/officehours
+---
+
+The XMPP Office Hours are presentations by the community on XMPP related topics.
+Anyone may give a presentation, and some of them are recorded and uploaded to
+our [YouTube Channel] for others to learn from later.
+
+If you'd like to present at the XMPP Office Hours, please fill out the form
+below and we'll be in touch shortly!
+
+{{< officehours >}}
+
+[YouTube Channel]: https://www.youtube.com/c/XMPPStandardsFoundation

--- a/layouts/shortcodes/officehours.html
+++ b/layouts/shortcodes/officehours.html
@@ -1,0 +1,4 @@
+<div class="row">
+<iframe src="https://xmpp-office-hours.netlify.app/form.html"
+				height="500"></iframe>
+</div>


### PR DESCRIPTION
I've been thinking that it might be nice to advertise the XMPP office hours a bit more on the community page of the website. Furthermore, it would be nice if the comm team were actually alerted when someone signs up. To do the second part I have been experimenting with a netlify form that emails us with the results (which we can then put on the schedule). Embedding it in the page looked nice and accomplished both goals in one. Thoughts?

![Screenshot of a form for submitting office hours signup requests](https://user-images.githubusercontent.com/512573/138447697-565756ff-323e-4c72-b5ba-11de477c1cb1.png)
