### PR TITLE
Add content security and referrer policy to website

### DIFF
--- a/deploy/xsf.conf
+++ b/deploy/xsf.conf
@@ -26,6 +26,9 @@ server {
         try_files $uri $uri/ $uri.html =404;
     }
 
+    add_header Content-Security-Policy "default-src 'self' xmpp.org; img-src *; connect-src 'none'; object-src 'none'; child-src xmpp-office-hours.netlify.app; frame-src xmpp-office-hours.netlify.app; worker-src 'none'; frame-ancestors 'none'; form-action 'self' xmpp-office-hours.netlify.app; upgrade-insecure-requests; block-all-mixed-content";
+    add_header Referrer-Policy "strict-origin-when-cross-origin";
+
     rewrite ^/about/compliance-suites-current$                  /extensions/xep-0443.html redirect;
     rewrite ^/feeds/all.atom.xml$                               /blog/index.xml;
     rewrite ^/category/easy-xmpp.html$                          /categories/easy-xmpp;

--- a/themes/xmpp.org/assets/js/err.js
+++ b/themes/xmpp.org/assets/js/err.js
@@ -1,0 +1,7 @@
+var errorEmojiContainer = document.getElementsByClassName('error-emoji')[0];
+var emojiArray = [
+  '\\(o_o)/', '(o^^)o', '(˚Δ˚)b', '(^-^*)', '(≥o≤)', '(^_^)b', '(·_·)',
+  '(=\'X\'=)', '(>_<)', '(;-;)', '\\(^Д^)/',
+];
+var errorEmoji = emojiArray[Math.floor(Math.random() * emojiArray.length)];
+errorEmojiContainer.appendChild(document.createTextNode(errorEmoji));

--- a/themes/xmpp.org/layouts/404.html
+++ b/themes/xmpp.org/layouts/404.html
@@ -8,13 +8,9 @@
       <p class="error-text">404 - Page not found</p>
     </div>
   </div>
-<script>
-  var errorEmojiContainer = document.getElementsByClassName('error-emoji')[0];
-  var emojiArray = [
-    '\\(o_o)/', '(o^^)o', '(˚Δ˚)b', '(^-^*)', '(≥o≤)', '(^_^)b', '(·_·)',
-    '(=\'X\'=)', '(>_<)', '(;-;)', '\\(^Д^)/',
-  ];
-  var errorEmoji = emojiArray[Math.floor(Math.random() * emojiArray.length)];
-  errorEmojiContainer.appendChild(document.createTextNode(errorEmoji));
-</script>
+  {{- with $err := resources.Get "js/err.js" }}
+  {{- with $secureErr := ($err | resources.Fingerprint "sha256") }}
+  <script src="{{ $err.RelPermalink }}" integrity="{{$secureErr.Data.Integrity}}"></script>
+  {{- end }}
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
I've put together a default policy that allows the office hours form, loading most resources from the `xmpp.org` domain, and disallows a few more dangerous resources that we don't use.

This also adds a referrer policy (no referrer sent on HTTPS/HTTP downgrade, otherwise just send the full thing since there are no "private" pages on the site and we may want others to know that we linked to them in a blog post or what not.

Other very minor changes were required to remove eg. unsafe JavaScript that would be blocked by the new policy.

Updates #152