### PR TITLE
New xmpp client

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -754,5 +754,5 @@
             "iOS"
         ],
         "url": "https://zom.im/"
-    }   
+    }
 ]

--- a/data/clients.json
+++ b/data/clients.json
@@ -744,5 +744,15 @@
             "iOS"
         ],
         "url": "https://zom.im/"
-    }
+    },
+    {
+        "doap": null,
+        "last_renewed": null,
+        "name": "Shmoose",
+        "platforms": [
+            "Sailfish OS",
+            "Linux"
+        ],
+        "url": "https://github.com/geobra/harbour-shmoose"
+    }    
 ]

--- a/data/clients.json
+++ b/data/clients.json
@@ -540,6 +540,16 @@
     {
         "doap": null,
         "last_renewed": null,
+        "name": "Shmoose",
+        "platforms": [
+            "Sailfish OS",
+            "Linux"
+        ],
+        "url": "https://github.com/geobra/harbour-shmoose"
+    },
+    {
+        "doap": null,
+        "last_renewed": null,
         "name": "Sim-IM",
         "platforms": [
             "FreeBSD",
@@ -744,15 +754,5 @@
             "iOS"
         ],
         "url": "https://zom.im/"
-    },
-    {
-        "doap": null,
-        "last_renewed": null,
-        "name": "Shmoose",
-        "platforms": [
-            "Sailfish OS",
-            "Linux"
-        ],
-        "url": "https://github.com/geobra/harbour-shmoose"
-    }    
+    }   
 ]


### PR DESCRIPTION
Add Shmoose, a xmpp client primary for the mobile operating system Sailfish OS. It's also runable on Linux.