### PR TITLE
Add Mellium Dev Communiqué to newsletter draft

### DIFF
--- a/content/blog/2021-12-05.md
+++ b/content/blog/2021-12-05.md
@@ -73,6 +73,14 @@ Openfire Smack publish [version 4.4.4 as patch level release](https://discourse.
 
 Developers and other standards experts from around the world collaborate on these extensions, developing new specifications for emerging practices, and refining existing ways of doing things. Proposed by anybody, the particularly successful ones end up as Final or Active - depending on their type - while others are carefully archived as Deferred. This life cycle is described in [XEP-0001](https://xmpp.org/extensions/xep-0001.html), which contains the formal and canonical definitions for the types, states, and processes. [Read more about the standards process](https://xmpp.org/about/standards-process.html). Communication around Standards and Extensions happens in the [Standards Mailing List](https://mail.jabber.org/mailman/listinfo/standards) ([online archive](https://mail.jabber.org/pipermail/standards/)).
 
+The Mellium [Dev Communiqué for November
+2021](https://opencollective.com/mellium/updates/dev-communique-for-november-2021)
+has been released!
+This month work mostly focused on the [carbons
+package](https://pkg.go.dev/mellium.im/xmpp/carbons) and on creating a re-usable
+test suite that other libraries can import to test [message
+styling](https://pkg.go.dev/mellium.im/xmpp/styling).
+
 ### Proposed
 
 The XEP development process starts by writing up an idea and submitting it to the XMPP Editor. Within two weeks, the Council decides whether to accept this proposal as an Experimental XEP.


### PR DESCRIPTION
Adds the Mellium [Dev Communiqué for November 2021](https://opencollective.com/mellium/updates/dev-communique-for-november-2021) to the newsletter.