### PR TITLE
Fix Shmoose platform order

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -542,8 +542,8 @@
         "last_renewed": null,
         "name": "Shmoose",
         "platforms": [
-            "Sailfish OS",
-            "Linux"
+            "Linux",
+            "Sailfish OS"
         ],
         "url": "https://github.com/geobra/harbour-shmoose"
     },


### PR DESCRIPTION
The site failed to build because platforms must be in alphabetical order:

```
python3 /var/tmp/src/xmpp.org/tools/lint-list.py clients.json
ERROR: entry 'Shmoose': platform order must be: 'Linux', 'Sailfish OS' (platforms must be ordered alphabetically)
Found 1 severe violations. Please fix them.
```