### PR TITLE
Add canonical link

### DIFF
--- a/themes/xmpp.org/layouts/partials/head.html
+++ b/themes/xmpp.org/layouts/partials/head.html
@@ -26,6 +26,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#212529">
+    <link rel="canonical" href="{{ .Permalink }}">
     <title>
       {{- if .IsHome }}
       {{- printf "%s | %s" .Site.Title (.Param "subtitle") }}


### PR DESCRIPTION
Supposedly helps SEO or something, especially when you might have the
same site served on both www.example.com and example.com
Also nice if you ever downloaded a page to know where it came from