### PR TITLE
Add Renga and Chat-O-Matic clients for Haiku

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -119,6 +119,15 @@
     },
     {
         "doap": null,
+        "last_renewed": "2022-02-14T00:00:00",
+        "name": "Chat-O-Matic",
+        "platforms": [
+            "Haiku"
+        ],
+        "url": "https://github.com/JadedCtrl/Chat-O-Matic"
+    },
+    {
+        "doap": null,
         "last_renewed": null,
         "name": "Candy",
         "platforms": [
@@ -543,6 +552,15 @@
             "Windows"
         ],
         "url": "https://qutim.org"
+    },
+    {
+        "doap": "https://raw.githubusercontent.com/pulkomandy/Renga/master/doap.xml",
+        "last_renewed": "2022-02-14T00:00:00",
+        "name": "Renga",
+        "platforms": [
+            "Haiku"
+        ],
+        "url": "https://github.com/pulkomandy/Renga"
     },
     {
         "doap": null,

--- a/data/platforms.json
+++ b/data/platforms.json
@@ -3,6 +3,7 @@
     "Browser",
     "BSD",
     "iOS",
+    "Haiku",
     "Linux",
     "macOS",
     "Other",


### PR DESCRIPTION
I'm not sure what the policy for adding things to platforms.json is.

These two clients are Haiku-only and use platform specific APIs
and user interface. I don't know if that should go under "Other"
which is not clearly documented.

Some of the already listed clients (Psi+, Poezio and BitlBee) are
also ported to Haiku but don't use anything platform specific, so
I didn't change them.