### PR TITLE
content/community/gsoc-2022.es.md: Fix GSoC Logo in ES translation

### DIFF
--- a/content/community/gsoc-2022.es.md
+++ b/content/community/gsoc-2022.es.md
@@ -2,7 +2,7 @@
 Title: XSF y Google Summer of Code 2022
 ---
 
-XSF y GSoC 2022 Logo](/images/logos/GSoC_2022_Logo.png)
+[XSF y GSoC 2022 Logo](/images/logos/GSoC_2022_Logo.png)
 
 _Por favor, ten en cuenta, que la comunicación principal sobre el tema está en inglés y sólo la información en inglés se considera oficial._
 


### PR DESCRIPTION
This has the fix to show correctly the GSoC Logo in ES translation, and has no merge conflics.