### PR TITLE
data: renew Mellium library registration

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -390,7 +390,7 @@
     },
     {
         "doap": null,
-        "last_renewed": "2021-03-29T00:00:00",
+        "last_renewed": "2022-03-29T00:00:00",
         "name": "Mellium",
         "platforms": [
             "Go"


### PR DESCRIPTION
Renewing. Left the day the same so it doesn't creep forward and make me adjust my calendar reminder by a week every year.