### PR TITLE
GSoC 2022: Update webpage and create blogpost

### DIFF
--- a/content/blog/2022-05-28-gsoc2022-welcome.md
+++ b/content/blog/2022-05-28-gsoc2022-welcome.md
@@ -1,6 +1,6 @@
 ---
 title: XMPP & Google Summer of Code 2022: Welcome new contributors!
-author: XSF Organization Administratior (GSoC 2022)
+author: XSF Organization Administrator (GSoC 2022)
 date: 2022-05-28
 categories: ['Google Summer of Code']
 ---
@@ -8,8 +8,7 @@ categories: ['Google Summer of Code']
 ![XSF and GSoC 2022 Logo](/images/logos/GSoC_2022_Logo.png)
 
 The Google Summer of Code 2022 is about to lift off and coding starts soon! The XSF has not just been 
-accepted (again!) as a hosting organisation for XMPP projects, we also can welcome two new contributors who will work on projects
-within the XMPP environment! We have updated our designated web-page for the Google Summer of Code 2022 accordingly.
+accepted (again!) as a hosting organization for XMPP projects, we also can welcome two new contributors who will work on open-source software projects in the XMPP environment! We have updated our designated web-page for the Google Summer of Code 2022 accordingly.
 
 ### The XMPP projects at Google Summer of Code 2022
 

--- a/content/blog/2022-05-28-gsoc2022-welcome.md
+++ b/content/blog/2022-05-28-gsoc2022-welcome.md
@@ -20,7 +20,7 @@ So, please welcome **Patiga** and **PawBud** as new contributors! It is really g
     - Unified handling of http and jingle (peer-to-peer) file transfers
     - Enable sending metadata alongside files
     - Thumbnail previews for images
-- **PawBud** will work towards adding support for [A/V communication via Jingle in ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19)
+- **PawBud** will work towards adding support for [A/V communication via Jingle in ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19). Mentors will be **JC Brand** and **vanitasvitae** - many thanks to both of you, too!
   - The idea is to add support for Audio & Video communication through the Jingle protocol. The goal is to create a Converse plugin that adds the ability to make one-on-one audio/video calls from Converse. The audio/video calls will be compatible with other XMPP clients.
 
 Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) or [Twitter](https://twitter.com/xmpp/status/1529199174729728000).

--- a/content/blog/2022-05-28-gsoc2022-welcome.md
+++ b/content/blog/2022-05-28-gsoc2022-welcome.md
@@ -1,0 +1,43 @@
+---
+title: XMPP & Google Summer of Code 2022: Welcome new contributors!
+author: XSF Organization Administratior (GSoC 2022)
+date: 2022-05-28
+categories: ['Google Summer of Code']
+---
+
+![XSF and GSoC 2022 Logo](/images/logos/GSoC_2022_Logo.png)
+
+The Google Summer of Code 2022 is about to lift off and coding starts soon! The XSF has not just been 
+accepted (again!) as a hosting organisation for XMPP projects, we also can welcome two new contributors who will work on projects
+within the XMPP environment! We have updated our designated web-page for the Google Summer of Code 2022 accordingly.
+
+### The XMPP projects at Google Summer of Code 2022
+
+So, please welcome **Patiga** and **PawBud** as new contributors! It is really great that you chose XMPP for your coding adventure!
+
+- **Patiga** will work on more [flexible file transfers in Dino](https://summerofcode.withgoogle.com/programs/2022/projects/z9ixHTWZ). Mentors will be **fiaxh** and **Marvin W.** - many thanks to both of you!
+  - Resource-wise, messenger applications tend to be on the lightweight side of the spectrum. This drastically changes when file transfers are added to the equation. File transfers can introduce arbitrary more resource-usage, both on network and data storage aspects. To alleviate this issue, stateless file sharing empowers the user to make informed decisions on which files to load. Deliverables:
+    - Unified handling of http and jingle (peer-to-peer) file transfers
+    - Enable sending metadata alongside files
+    - Thumbnail previews for images
+- **PawBud** will work towards adding support for [A/V communication via Jingle in ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19)
+  - The idea is to add support for Audio & Video communication through the Jingle protocol. The goal is to create a Converse plugin that adds the ability to make one-on-one audio/video calls from Converse. The audio/video calls will be compatible with other XMPP clients.
+
+Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) or [Twitter](https://twitter.com/xmpp/status/1529199174729728000).
+
+ ### Resources
+
+- [Google's website](https://summerofcode.withgoogle.com/help)
+- [XSF wiki](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022)
+- Reach us [via web chat](https://xmpp.org/chat#converse/room?jid=gsoc@muc.xmpp.org) or review your ["Getting started with XMPP"](https://xmpp.org/getting-started/) page and reach us via our [public chat](xmpp:gsoc@muc.xmpp.org?join).
+
+Checkout our media channels, too!
+
+- [Twitter](https://twitter.com/xmpp)
+- [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
+- [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
+
+
+Looking forward!
+
+ –The XSF Organisation Admin

--- a/content/blog/2022-05-28-gsoc2022-welcome.md
+++ b/content/blog/2022-05-28-gsoc2022-welcome.md
@@ -8,7 +8,7 @@ categories: ['Google Summer of Code']
 ![XSF and GSoC 2022 Logo](/images/logos/GSoC_2022_Logo.png)
 
 The Google Summer of Code 2022 is about to lift off and coding starts soon! The XSF has not just been 
-accepted (again!) as a hosting organization for XMPP projects, we also can welcome two new contributors who will work on open-source software projects in the XMPP environment! We have updated our designated web-page for the Google Summer of Code 2022 accordingly.
+accepted (again!) as a hosting organization for XMPP projects, we also can welcome two new contributors who will work on open-source software projects in the XMPP environment! We have updated our [designated web-page](https://xmpp.org/community/gsoc-2022/) for the Google Summer of Code 2022 accordingly.
 
 ### The XMPP projects at Google Summer of Code 2022
 

--- a/content/community/gsoc-2022.en.md
+++ b/content/community/gsoc-2022.en.md
@@ -4,10 +4,9 @@ Title: XSF and Google Summer of Code 2022
 
 ![XSF and GSoC 2022 Logo](/images/logos/GSoC_2022_Logo.png)
 
-The XMPP Standards Foundation (XSF) is planning to participate as a hosting organisation in the [Google Summer of Code 2022](https://summerofcode.withgoogle.com/).
-If you are interested to participate as student (or simply newcomer to open-source), mentor or XMPP project this is the page to start with!
+The XMPP Standards Foundation (XSF) participates as a hosting organisation in the [Google Summer of Code 2022](https://summerofcode.withgoogle.com/).
  
-If you can imagine yourself part time (or even full time) working on an open-source software project during the summer, then consider to join an XMPP real-time communication technology project and participate in the Google Summer of Code 2022!
+As many many others, this year two contributors will work on an open-source software projects in the XMPP real-time communication technology ecosystem during the summer.
 
 ### XMPP - the Extensible Messaging and Presence Protocol
 
@@ -21,16 +20,21 @@ The Google Summer of Code is an international annual program in which Google awa
 
 - [Converse.js](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022#Converse.js): Converse is a web-based XMPP client. It has different modes, allowing it to be integrated into existing websites, used as a webchat for a specific chatroom, or used as a full-fledged XMPP client on its own. There is also an electron-based version available.
 - [Dino](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022#Dino): Dino is a modern open-source chat client for the desktop. It focuses on providing a clean and reliable Jabber/XMPP experience while having your privacy in mind.
-- [Psi](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022#Psi): An XMPP client for advanced users.
-- [PGPainless](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022#PGPainless): PGPainless is a Java OpenPGP library. While it is not strictly an XMPP related project, it has its origins in GSoC and the XMPP community, since it was created as a Summer of Code project in 2018.
 
-### First steps
+### Welcome new contributors!
 
-If you want to participate we recommoned the following preparations:
+Our contributors are Patiga and PawBud - warm welcome and its great that you chose XMPP for your coding adventure!
 
-- Read the resources at [Google's website](https://summerofcode.withgoogle.com/help) and review if this is something suitable to you and your plans this year.
-- Take a first look at our XMPP project detail page in the [XSF wiki](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022) (work in progress).
-- You can simply reach us [via web chat](https://xmpp.org/chat#converse/room?jid=gsoc@muc.xmpp.org) or review your ["Getting started with XMPP"](https://xmpp.org/getting-started/) page and reach us via our [public chat](xmpp:gsoc@muc.xmpp.org?join).
+- Patiga will work on more [flexible file transfers in Dino](https://summerofcode.withgoogle.com/programs/2022/projects/z9ixHTWZ)
+- PawBud will work towards adding support for [A/V communication via Jingle in ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19)
+
+Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) or [Twitter](https://twitter.com/xmpp/status/1529199174729728000).
+
+### Resources
+
+- [Google's website](https://summerofcode.withgoogle.com/help)
+- [XSF wiki](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022)
+- Reach us [via web chat](https://xmpp.org/chat#converse/room?jid=gsoc@muc.xmpp.org) or review your ["Getting started with XMPP"](https://xmpp.org/getting-started/) page and reach us via our [public chat](xmpp:gsoc@muc.xmpp.org?join).
 
 Checkout our media channels!
 
@@ -38,12 +42,10 @@ Checkout our media channels!
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 
-Furthermore you are invited to [promote this upcoming event with our flyer](/images/promo/Flyer_XMPP_GSoC2022_EN.pdf) locally at designated places like blackboards. Please be so kind and ask if you are allowed to place the flyer.
-
-Looking forward and stay tuned!
+Looking forward!
  –The XSF Organisation Admin
 
 ### Sources
 
 - Google Summer of Code, Wikipedia contributors, Wikipedia, The Free Encyclopedia, 22 November 2021 23:03 UTC, 22 January 2022 14:31 UTC, [Permanent Link](https://en.wikipedia.org/w/index.php?title=Google_Summer_of_Code&oldid=1056637774)
-- GSoC-icon.svg, Wikimedia Commons contributors, Wikimedia Commons, the free media repository, Date of last revision: 17 June 2021 12:10 UTC, 22 January 2022 14:33 UTC, [Permanent Link](https://commons.wikimedia.org/w/index.php?title=File:GSoC-icon.svg&oldid=569574711), 569574711
+- GSoC-icon.svg, Wikimedia Commons contributors, Wikimedia Commons, the free media repository, Date of last revision: 17 June 2021 12:10 UTC, 22 January 2022 14:33 UTC, [permanent link](https://commons.wikimedia.org/w/index.php?title=File:GSoC-icon.svg&oldid=569574711), 569574711

--- a/content/community/gsoc-2022.en.md
+++ b/content/community/gsoc-2022.en.md
@@ -6,7 +6,7 @@ Title: XSF and Google Summer of Code 2022
 
 The XMPP Standards Foundation (XSF) participates as a hosting organisation in the [Google Summer of Code 2022](https://summerofcode.withgoogle.com/).
  
-As many many others, this year two contributors will work on an open-source software projects in the XMPP real-time communication technology ecosystem during the summer.
+As with many others, this year two contributors will work on an open-source software projects in the XMPP real-time communication technology ecosystem during the summer.
 
 ### XMPP - the Extensible Messaging and Presence Protocol
 
@@ -21,7 +21,7 @@ The Google Summer of Code is an international annual program in which Google awa
 - [Converse.js](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022#Converse.js): Converse is a web-based XMPP client. It has different modes, allowing it to be integrated into existing websites, used as a webchat for a specific chatroom, or used as a full-fledged XMPP client on its own. There is also an electron-based version available.
 - [Dino](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022#Dino): Dino is a modern open-source chat client for the desktop. It focuses on providing a clean and reliable Jabber/XMPP experience while having your privacy in mind.
 
-### Welcome new contributors!
+### Welcome to our new contributors!
 
 Our contributors are Patiga and PawBud - warm welcome and its great that you chose XMPP for your coding adventure!
 
@@ -42,7 +42,7 @@ Checkout our media channels!
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 
-Looking forward!
+We are looking forward to your projects!
  –The XSF Organisation Admin
 
 ### Sources


### PR DESCRIPTION
- Update webpage
- Create blogpost

@wurstsalat3000 Github somehow tells me this: 

> The 'xsf/xmpp.org' repository doesn't contain the 'images/logos/GSoC_2022_Logo.png' path in 'master'. 

But is is actually correct I think. Any issues you see?