### PR TITLE
content/community/gsoc-2022.en.md: Fix content typo

### DIFF
--- a/content/community/gsoc-2022.en.md
+++ b/content/community/gsoc-2022.en.md
@@ -34,7 +34,7 @@ Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/10835882
 
 - [Google's website](https://summerofcode.withgoogle.com/help)
 - [XSF wiki](https://wiki.xmpp.org/web/Google_Summer_of_Code_2022)
-- Reach us [via web chat](https://xmpp.org/chat#converse/room?jid=gsoc@muc.xmpp.org) or review your ["Getting started with XMPP"](https://xmpp.org/getting-started/) page and reach us via our [public chat](xmpp:gsoc@muc.xmpp.org?join).
+- Reach us [via web chat](https://xmpp.org/chat#converse/room?jid=gsoc@muc.xmpp.org) or review our ["Getting started with XMPP"](https://xmpp.org/getting-started/) page and reach us via our [public chat](xmpp:gsoc@muc.xmpp.org?join).
 
 Checkout our media channels!
 


### PR DESCRIPTION
Fix a typo in gsoc-2022 EN version