### PR TITLE
Allow projects to put logo URL in JSON or DOAP

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -395,7 +395,8 @@
         "platforms": [
             "Go"
         ],
-        "url": "https://mellium.im/code"
+        "url": "https://mellium.im/code",
+        "logo": "https://mellium.im/mellium_icon.png"
     },
     {
         "doap": null,

--- a/tools/lint_list.py
+++ b/tools/lint_list.py
@@ -13,12 +13,15 @@ from datetime import datetime
 from datetime import timedelta
 
 
-VALID_ENTRY_KEYS = {
+REQUIRED_ENTRY_KEYS = {
     "platforms",
     "name",
     "last_renewed",
     "doap",
     "url",
+}
+VALID_ENTRY_KEYS = {
+        "logo",
 }
 
 
@@ -50,8 +53,8 @@ def check_entries(entries: dict[str, Any],
             violations += 1
 
         entry_keys = set(entry.keys())
-        unknown = entry_keys - VALID_ENTRY_KEYS
-        missing = VALID_ENTRY_KEYS - entry_keys
+        unknown = entry_keys - REQUIRED_ENTRY_KEYS - VALID_ENTRY_KEYS
+        missing = REQUIRED_ENTRY_KEYS - entry_keys
 
         if unknown:
             emit_violation(

--- a/tools/prepare_software_list.py
+++ b/tools/prepare_software_list.py
@@ -268,6 +268,8 @@ def prepare_package_list(package_type: str) -> None:
         logo_uri = None
         if parsed_package_infos['logo'] is not None:
             logo_uri = process_logo(package_name, parsed_package_infos['logo'])
+        elif 'logo' in package.keys() and package['logo'] is not None:
+            logo_uri = process_logo(package_name, package['logo'])
 
         added_to_other = False
         for package_os in parsed_package_infos['os']:


### PR DESCRIPTION
Currently only DOAP projects can have a nice logo, and those of us without are being left behind. This patch adds a logo field to the JSON so that the site doesn't have as many ugly projects with generic logos and everyone can have a pretty logo.