### PR TITLE
Update public server listing links

### DIFF
--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -40,10 +40,9 @@ Use a [public provider from the curated list of **XMPP Providers**](https://prov
 **XMPP Providers** takes various aspects into consideration to recommend providers.
 There are several other (uncurated) lists of providers:
 
+* [Curated XMPP server list at providers.xmpp.net](https://providers.xmpp.net/)
 * [Public XMPP servers by jabber.at](https://list.jabber.at)
 * [Open list of public XMPP servers by 404.city](https://xmpp-servers.404.city)
-* [Public XMPP Server Directory by IM Observatory](https://xmpp.net/directory.php)
-* [XMPP Compliance Tester results](https://compliance.conversations.im/old/)
 
 ## 3. Log in! That's it
 


### PR DESCRIPTION
The link to IM Observatory was broken, as that service is now retired. I've replaced it by a link to the new providers.xmpp.net.

I've removed the link to compliance.conversations.im. That data is factored into ratings on providers.xmpp.net and, at the time of writing, the service has an uncertain future.