### PR TITLE
Fix and rename Service Providers link

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -119,8 +119,8 @@
     parent = "community"
     weight = 6
 [[main]]
-    name = "Service Providers"
-    url = "https://xmpp.work/all-listings"
+    name = "Jobs using XMPP"
+    url = "https://xmpp.work/"
     parent = "community"
     weight = 7
 [[main]]

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -119,7 +119,7 @@
     parent = "community"
     weight = 6
 [[main]]
-    name = "Jobs using XMPP"
+    name = "Jobs with XMPP"
     url = "https://xmpp.work/"
     parent = "community"
     weight = 7


### PR DESCRIPTION
The Service Providers link (in Community and the right side of some pages) linked to a now-missing link on xmpp.work

I have:
* Fixed the link to point at the root of https://xmpp.work
* Updated the name of the link to more accurately reflect the purpose of xmpp.work