### PR TITLE
/software/: Use words to describe compliance

### DIFF
--- a/themes/xmpp.org/layouts/shortcodes/software-overview-doap.html
+++ b/themes/xmpp.org/layouts/shortcodes/software-overview-doap.html
@@ -249,7 +249,8 @@
                                         <i class="fa-solid fa-check text-primary" title="{{- $props.badges.core | title -}}"></i>
                                     {{- else -}}
                                         <i class="fa-solid fa-check-double text-primary" title="{{- $props.badges.core | title -}}"></i>
-                                    {{- end -}}
+                                    {{- end -}}<br>
+                                    {{- $props.badges.core | title -}}
                                 {{- else -}}
                                     -
                                 {{- end -}}
@@ -261,7 +262,8 @@
                                         <i class="fa-solid fa-check text-primary" title="{{- $props.badges.im | title -}}"></i>
                                     {{- else -}}
                                         <i class="fa-solid fa-check-double text-primary" title="{{- $props.badges.im | title -}}"></i>
-                                    {{- end -}}
+                                    {{- end -}}<br>
+                                    {{- $props.badges.im | title -}}
                                 {{- else -}}
                                     -
                                 {{- end -}}
@@ -273,7 +275,8 @@
                                         <i class="fa-solid fa-check text-primary" title="{{- $props.badges.mobile | title -}}"></i>
                                     {{- else -}}
                                         <i class="fa-solid fa-check-double text-primary" title="{{- $props.badges.mobile | title -}}"></i>
-                                    {{- end -}}
+                                    {{- end -}}<br>
+                                    {{- $props.badges.mobile | title -}}
                                 {{- else -}}
                                     -
                                 {{- end -}}
@@ -285,7 +288,8 @@
                                         <i class="fa-solid fa-check text-primary" title="{{- $props.badges.web | title -}}"></i>
                                     {{- else -}}
                                         <i class="fa-solid fa-check-double text-primary" title="{{- $props.badges.web | title -}}"></i>
-                                    {{- end -}}
+                                    {{- end -}}<br>
+                                    {{- $props.badges.web | title -}}
                                 {{- else -}}
                                     -
                                 {{- end -}}
@@ -297,7 +301,8 @@
                                         <i class="fa-solid fa-check text-primary" title="{{- $props.badges.av | title -}}"></i>
                                     {{- else -}}
                                         <i class="fa-solid fa-check-double text-primary" title="{{- $props.badges.av | title -}}"></i>
-                                    {{- end -}}
+                                    {{- end -}}<br>
+                                    {{- $props.badges.av | title -}}
                                 {{- else -}}
                                     -
                                 {{- end -}}


### PR DESCRIPTION
The existing approach used a custom font to render some icons as the only way of describing compliance level. For clients that don't load or render custom remote fonts, this information is invisible. For clients that do render fonts, the meaning of these icons is a mystery.

Additionally, for users with screen readers or similar assistive technologies, these icons are also meaningless (especially since they have no "alt").

This patch adds the actual words to describe the compliance level, so that the information can be easily consumed by humans.