### PR TITLE
Document development dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You need to have the following dependencies installed:
 
 * Hugo
 * Python 3
-* lua 5.2
+* lua 5.2 and lua-expat
 
 The development server will automatically rebuild the page whenever a file is changed:
 


### PR DESCRIPTION
This was missing from the README but is used under the hood by a python script that generates data for the compliance page.