### PR TITLE
Explicitly use lua5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get dist-upgrade -y && apt-get autoremove -y && apt-get clean
 
 # Install dependencies.
-RUN apt-get install -y hugo lua5.2 lua-expat python3 python3-pip
+RUN apt-get install -y hugo lua5.4 lua-expat python3 python3-pip
 
 # Base URL for Hugo website builds
 ARG BASEURL=https://xmpp.org/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You need to have the following dependencies installed:
 
 * Hugo
 * Python 3
-* lua 5.2 and lua-expat
+* lua 5.4 and lua5.4-expat
 
 The development server will automatically rebuild the page whenever a file is changed:
 

--- a/tools/prepare_compliance.py
+++ b/tools/prepare_compliance.py
@@ -22,7 +22,7 @@ def generate_compliance_json() -> None:
     '''
     try:
         result = subprocess.check_output([
-            'lua',
+            'lua5.4',
             f'{DOWNLOAD_PATH}/compliancer',
             '-v',
             f'{DOWNLOAD_PATH}/compliance-suite.xml'])
@@ -65,7 +65,7 @@ def check_packages_compliance() -> None:
         for file in files:
             try:
                 result = subprocess.check_output([
-                    'lua',
+                    'lua5.4',
                     f'{DOWNLOAD_PATH}/compliancer',
                     '-v',
                     f'{DOWNLOAD_PATH}/compliance-suite.xml',


### PR DESCRIPTION
The binary "lua" might point to a different version. Given that this specific version is indicated as a dependency, make sure the matching version is used.

In particular, this avoids issues on distributions which make 5.1 the default (since some modules are missing for it).