### PR TITLE
Add Moxxy, moxxmpp, and omemo_dart to the software list

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -1218,6 +1218,15 @@
         "categories": [
             "client"
         ],
+        "doap": "https://codeberg.org/moxxy/moxxy/raw/branch/master/moxxy.doap",
+        "name": "Moxxy",
+        "platforms": [],
+        "url": null
+    },
+    {
+        "categories": [
+            "client"
+        ],
         "doap": null,
         "name": "Mozilla Thunderbird",
         "platforms": [

--- a/data/software.json
+++ b/data/software.json
@@ -1298,6 +1298,15 @@
     },
     {
         "categories": [
+            "library"
+        ],
+        "doap": "https://raw.githubusercontent.com/PapaTutuWawa/omemo_dart/master/omemo_dart.doap",
+        "name": "omemo_dart",
+        "platforms": [],
+        "url": null
+    },
+    {
+        "categories": [
             "server"
         ],
         "doap": "https://raw.githubusercontent.com/igniterealtime/Openfire/main/documentation/openfire.doap",

--- a/data/software.json
+++ b/data/software.json
@@ -1216,6 +1216,15 @@
     },
     {
         "categories": [
+            "library"
+        ],
+        "doap": "https://codeberg.org/moxxy/moxxmpp/raw/branch/master/packages/moxxmpp/moxxmpp.doap",
+        "name": "moxxmpp",
+        "platforms": [],
+        "url": "https://codeberg.org/moxxy/moxxmpp/src/branch/master/packages/moxxmpp"
+    },
+    {
+        "categories": [
             "client"
         ],
         "doap": "https://codeberg.org/moxxy/moxxy/raw/branch/master/moxxy.doap",


### PR DESCRIPTION
This PR adds [Moxxy](https://codeberg.org/moxxy/moxxy) (XMPP client), [moxxmpp](https://codeberg.org/moxxy/moxxmpp) (Moxxy's XMPP library), and [omemo_dart](https://github.com/PapaTutuWawa/omemo_dart) (Moxxy's implementation of OMEMO) to the software list.