### PR TITLE
Update software mentioned on infra page

### DIFF
--- a/content/about/xsf/infrastructure-team.md
+++ b/content/about/xsf/infrastructure-team.md
@@ -10,10 +10,9 @@ The XSF’s Infrastructure Team is responsible for maintaining and improving the
 
 - Several physical server machines hosted at USSHC
 - Operating system maintenance (Debian GNU/Linux)
-- Web server and associated software (lighttpd, MySQL, WordPress, MediaWiki)
+- Web server and associated software (nginx, MediaWiki)
 - Tools for XEP publication (Python scripts, shell scripts, XSLT)
 - Email server and list software (Postfix and Mailman)
-- Source control (Subversion and various products donated by Atlassian)
 - XMPP server, chatrooms, and bots (Prosody and homegrown software)
 - DNS (Bind, with mirrors)
 - Digital certificates


### PR DESCRIPTION
We don't have any lighttpd anymore, replaced by nginx

The website has also passed trough at least two software changes and is now a static site based on Hugo, no WordPress anymore.

And Github has replaced Subversion. I think we used Mercurial inbetween. Currently no self-hosted version control.