### PR TITLE
iteam membership updates

### DIFF
--- a/data/members.json
+++ b/data/members.json
@@ -261,7 +261,7 @@
         {
             "name": "Jonas Schäfer",
             "jids": ["jonas@wielicki.name"],
-            "roles": ["council", "editor", "infrastructure"]
+            "roles": ["council", "infrastructure"]
         },
 
         {

--- a/data/members.json
+++ b/data/members.json
@@ -48,7 +48,8 @@
     "members": [
         {
             "name": "Kim Alvefur",
-            "jids": ["zash@zash.se"]
+            "jids": ["zash@zash.se"],
+            "roles": ["infrastructure"]
         },
 
         {
@@ -127,7 +128,8 @@
 
         {
             "name": "Stephen Paul Weber",
-            "jids": ["singpolyma@singpolyma.net"]
+            "jids": ["singpolyma@singpolyma.net"],
+            "roles": ["infrastructure"]
         },
 
         {
@@ -171,7 +173,8 @@
 
         {
             "name": "Trevor Krahn",
-            "jids": ["root@nicolosus.chat"]
+            "jids": ["root@nicolosus.chat"],
+            "roles": ["infrastructure"]
         },
 
         {
@@ -192,10 +195,9 @@
 
         {
             "name": "Tobias Markmann",
-            "jids": ["tm@ayena.de"],
-            "roles": ["infrastructure"]
+            "jids": ["tm@ayena.de"]
         },
-        
+
         {
             "name": "Ali Mattouk",
             "jids": ["xnamed@jix.im", "admin@jabber.eu.org"]
@@ -259,7 +261,7 @@
         {
             "name": "Jonas Schäfer",
             "jids": ["jonas@wielicki.name"],
-            "roles": ["council", "editor"]
+            "roles": ["council", "editor", "infrastructure"]
         },
 
         {


### PR DESCRIPTION
This updates the team membership for iteam, per recent voting on the team list.

As a minor aside, it also amends the editor team listing to remove Jonas, who resigned from that role earlier this year.

Commit messages have more details.