### PR TITLE
extensions-table.js: make all XEPs visible when slash/find key pressed

### DIFF
--- a/themes/xmpp.org/static/js/extensions-table.js
+++ b/themes/xmpp.org/static/js/extensions-table.js
@@ -19,4 +19,14 @@ window.addEventListener("load", function() {
   jsSupport.forEach(function(elem) {
     elem.classList.remove("jsSupport");
   });
+
+  document.addEventListener("keypress", function (event) {
+    if (event.code != "Slash" && event.code != "Find") {
+      return;
+    }
+    checkboxes.forEach(function (checkbox) {
+      checkbox.checked = true;
+      show_hide(checkbox);
+    });
+  });
 });


### PR DESCRIPTION
We don't currently have any in-page facility for searching across XEPs (e.g. by title). That's fine, as browsers typically offer this functionality. However currently to perform such a search, you have to tick all the checkboxes manually before performing the search.

This small addition to the code will automatically enable all checkboxes, thus revealing all XEPs, when the user presses the "/" key, which triggers a quick find-in-page functionality in at least Firefox.

Known issues:

- Not all browsers search when "/" is pressed (and catching Ctrl+F is not easy)
- It's not discoverable (this is a feature and a bug - I am a fan of quiet enhancements, but there may be people/environments for which an inline search would be preferable)

These issues should not degrade anyone's experience compared to what we have today, but it will be a small improvement for some people (including me).