### PR TITLE
Remove Blabber.im from Getting Started

### DIFF
--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -22,7 +22,6 @@ There are [plenty of XMPP apps/clients](/software/) for you to choose from. To g
 
 ### Android
 
-* {{< external-link text="blabber.im" url="https://blabber.im/" >}}
 * {{< external-link text="Conversations" url="https://conversations.im/" >}}
 * {{< external-link text="Quicksy" url="https://quicksy.im/" >}}
 * {{< external-link text="Yaxim" url="https://yax.im" >}}


### PR DESCRIPTION
Blabber is not under active development¹. And while there isn’t one giant security gotcha there are a few security related things that add up such as vulnerability in backup format, outdated libwebrtc, possible SDP injection. All in all enough that we shouldn’t be recommending it anymore.

¹: https://codeberg.org/kriztan/blabber.im