### PR TITLE
Extensions: Focus search input when pressing 'Slash' or 'Find'

### DIFF
--- a/themes/xmpp.org/static/js/scripts.js
+++ b/themes/xmpp.org/static/js/scripts.js
@@ -38,8 +38,17 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   if (window.location.pathname == "/extensions/") {
+    const xep_search_input = document.getElementById("xep-search-input")
+
+    document.addEventListener("keypress", function (event) {
+      if (event.code != "Slash" && event.code != "Find") {
+        return;
+      }
+      xep_search_input.focus();
+    });
+
     // XEP checkboxes and search bar
-    document.getElementById("xep-search-input").addEventListener("input", filter_xeps)
+    xep_search_input.addEventListener("input", filter_xeps)
 
     const checkboxes = document.querySelectorAll("#status-selector input");
     for (const checkbox of checkboxes) {


### PR DESCRIPTION
@mwild1 does this work for you? I can't seem to test this.

Reference: #1304 