### PR TITLE
extensions-table: check deferred XEPs

### DIFF
--- a/themes/xmpp.org/layouts/shortcodes/extensions-table.html
+++ b/themes/xmpp.org/layouts/shortcodes/extensions-table.html
@@ -26,7 +26,7 @@
                         <label class="form-check-label" for="Experimental">Experimental</label>
                     </div>
                     <div class="form-check form-check-inline">
-                        <input class="form-check-input" type="checkbox" id="Deferred" name="Deferred" />
+                        <input class="form-check-input" type="checkbox" id="Deferred" name="Deferred" checked="checked" />
                         <label class="form-check-label" for="Deferred">Deferred</label>
                     </div>
                     <div class="form-check form-check-inline">


### PR DESCRIPTION
Deferred XEPs are just as relevant as the XEPs of other XEP-states that are checked by default. For example, XEP-0447 (experimental) depends on XEP-0103 and XEP-0104 (both deferred).

I don't think we should present a XEP and not its dependencies per default.