### PR TITLE
Updates to chatrooms page

### DIFF
--- a/content/community/chat.md
+++ b/content/community/chat.md
@@ -7,25 +7,28 @@ aliases:
 
 {{< user-support-chat >}}
 
-The XSF hosts a variety of chat rooms and all archives are available online.
+The XSF hosts a variety of chat rooms and all archives are available online. Participation in the XSF's discussion channels is subject to the [Community Code of Conduct](https://xmpp.org/extensions/xep-0458.html).
 
-### Overview of logs
-Overview of the logs of XSF chatrooms ([logs](https://logs.xmpp.org/))
+### Archives
+
+Logs of XSF public chatrooms are available at [logs.xmpp.org](https://logs.xmpp.org/).
 
 ### XSF chatroom
-Chat about the XMPP standards process ([join](xmpp:xsf@muc.xmpp.org?join) | [logs](http://logs.xmpp.org/xsf/) | [webchat](https://xmpp.org/chat?xsf))
+Chat about the XMPP Standards Foundation itself, including the standards process. ([join](xmpp:xsf@muc.xmpp.org?join) | [logs](http://logs.xmpp.org/xsf/) | [webchat](https://xmpp.org/chat?xsf))
+
+### Developer chatroom
+Ask questions about developing XMPP software. ([join](xmpp:jdev@muc.xmpp.org?join) | [logs](http://logs.xmpp.org/jdev/) | [webchat](https://xmpp.org/chat?jdev))
+
+### Operators chatroom
+A place for civil discussion between XMPP server operators about the XMPP network. Anyone may join and follow discussions. To reduce noise, active participation is limited to XSF members and server operators, see the [channel guidelines](/community/channels/operators/) for more information. ([join](xmpp:operators@muc.xmpp.org?join) | [logs](http://logs.xmpp.org/operators/) | [webchat](https://xmpp.org/chat?operators))
 
 ### Council chatroom
-The Council meets once a week in this chatroom - anyone can join in, comments from the floor are welcome ([join](xmpp:council@muc.xmpp.org?join) |
+The Council meets once a week in this chatroom - anyone can join in, comments from the floor are welcome. ([join](xmpp:council@muc.xmpp.org?join) |
 [logs](https://logs.xmpp.org/council/) | [webchat](https://xmpp.org/chat?council))
 
 ### Editors chatroom
 Chat about the XMPP standards process and the editorial work ([join](xmpp:editor@muc.xmpp.org?join) | [logs](http://logs.xmpp.org/editor/) | [webchat](https://xmpp.org/chat?editor))
 
-### Developer chatroom
-Chat about build software with XMPP ([join](xmpp:jdev@muc.xmpp.org?join) | [logs](http://logs.xmpp.org/jdev/) | [webchat](https://xmpp.org/chat?jdev))
+### Other chatrooms
 
-### Operators chatroom
-Chat about running XMPP services ([join](xmpp:operators@muc.xmpp.org?join) | [logs](http://logs.xmpp.org/operators/) | [webchat](https://xmpp.org/chat?operators))
-
-All of these venues are completely free and open to any interested individual. Community chats for software support etc. can be found via [XMPP Chat Room Search Engine](https://search.jabber.network/rooms/1) (not related to XSF business or hosting).
+Additionally, community chats for software support and other topics can be found via [XMPP Chat Room Search Engine](https://search.jabber.network/rooms/1) (the search engine and external chats are not hosted or operated by the XSF).


### PR DESCRIPTION
Some reorganization and updates:

- Link to CoC
- Update description of operators channel (not currently open to general public participation)
- Remove "free and open to all" wording, due to the above restriction
- Expand disclaimer about search.jabber.network and third-party chats
- Reorder room listing to put more general and widely-applicable chats towards the top
- Improve some descriptions