### PR TITLE
Remove link to unofficial Kik messenger repo

### DIFF
--- a/content/uses/instant-messaging.md
+++ b/content/uses/instant-messaging.md
@@ -20,7 +20,7 @@ There are also many, mostly commerical projects that have created an XMPP-based 
 | Users        | Company                         | Description                            |
 |--------------|---------------------------------|----------------------------------------|
 | ~2 billion   | [WhatsApp](https://www.whatsapp.com/about) | WhatApp uses a [variation of XMPP](https://developers.facebook.com/m/messaging-interoperability) for its popular chat service |
-| ~300 million | [Kik Messenger](https://www.kik.com/) | Kik Messenger uses a [variation of XMPP](https://github.com/tomer8007/kik-bot-api-unofficial) for its popular chat service. |
+| ~300 million | [Kik Messenger](https://www.kik.com/) | Kik Messenger uses a variation of XMPP for its popular chat service. |
 | ~200 million | [Zoom](https://zoom.us)         | Zoom uses [XMPP (with some proprietary extensions) for its chat functionality](https://blog.talosintelligence.com/2020/04/zoom-user-enumeration.html). |
 |  ~20 million | [Jitsi](https://jitsi.org)      | [Jitsi](https://jitsi.org/about/) is a free and open source project that enables video-conferences. It uses XMPP for its chat functionality. |
 | ~6.5 million | [Moya App](https://moya.app/)   | A chat app and social communication platform mainly [used in South Africa](https://www.businessinsider.co.za/the-moyaapp-has-6m-active-users-and-challenging-whatsapp-2022-8). |


### PR DESCRIPTION
It's been reported that at https://xmpp.org/uses/instant-messaging/ there is a link to a repository owned by a GitHub account that is owned by a cracker group that uses the API to build spambots on the XMPP network.

I'm unsure of the affiliation of the repository owner. The link is of limited added value to the XSF website. To err on the side of caution, this commit removes that link.

fixes https://github.com/xsf/xmpp.org/issues/1372