### PR TITLE
Add aTalk client (with a DOAP file)

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -120,6 +120,15 @@
     },
     {
         "categories": [
+            "client"
+        ],
+        "doap": "https://raw.githubusercontent.com/cmeng-git/atalk-android/master/atalk.doap",
+        "name": "aTalk",
+        "platforms": [],
+        "url": null
+    },
+    {
+        "categories": [
             "library"
         ],
         "doap": null,


### PR DESCRIPTION
DOAP file for aTalk has just been added: https://github.com/cmeng-git/atalk-android/pull/214