### PR TITLE
Update "Other Software" list

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -1261,7 +1261,7 @@
         "platforms": [
             "Perl"
         ],
-        "url": null
+        "url": "https://metacpan.org/pod/Net::XMPP"
     },
     {
         "categories": [
@@ -2142,7 +2142,7 @@
             "library"
         ],
         "doap": null,
-        "name": "xmppframework",
+        "name": "XMPPFramework",
         "platforms": [
             "Objective C"
         ],
@@ -2153,7 +2153,7 @@
             "library"
         ],
         "doap": null,
-        "name": "xmpphp",
+        "name": "XMPPHP",
         "platforms": [
             "PHP"
         ],

--- a/data/software.json
+++ b/data/software.json
@@ -228,6 +228,17 @@
             "client"
         ],
         "doap": null,
+        "name": "BombusMod",
+        "platforms": [
+            "Android"
+        ],
+        "url": "https://github.com/BombusMod/BombusMod"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
         "name": "Boogie Chat",
         "platforms": [
             "iOS"
@@ -384,6 +395,19 @@
         "name": "Converse.js",
         "platforms": [],
         "url": null
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "CoyIM",
+        "platforms": [
+            "Linux",
+            "macOS",
+            "Windows"
+        ],
+        "url": "https://coy.im"
     },
     {
         "categories": [
@@ -801,6 +825,17 @@
     },
     {
         "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "JabberCat",
+        "platforms": [
+            "Linux"
+        ],
+        "url": "https://jabbercat.org"
+    },
+    {
+        "categories": [
             "server"
         ],
         "doap": null,
@@ -846,6 +881,19 @@
             "macOS"
         ],
         "url": "https://github.com/ortuman/jackal"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "Jackline",
+        "platforms": [
+            "BSD",
+            "Linux",
+            "macOS"
+        ],
+        "url": "https://github.com/hannesm/jackline"
     },
     {
         "categories": [
@@ -977,6 +1025,20 @@
             "Browser"
         ],
         "url": "https://github.com/getkaiwa/kaiwa"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "Kontalk",
+        "platforms": [
+            "Android",
+            "Linux",
+            "macOS",
+            "Windows"
+        ],
+        "url": "https://www.kontalk.org"
     },
     {
         "categories": [
@@ -1778,6 +1840,20 @@
             "client"
         ],
         "doap": null,
+        "name": "Vacuum-IM",
+        "platforms": [
+            "FreeBSD",
+            "Linux",
+            "macOS",
+            "Windows"
+        ],
+        "url": "https://github.com/vacuum-im/vacuum-im"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
         "name": "Vayusphere",
         "platforms": [
             "BlackBerry"
@@ -1876,6 +1952,17 @@
             "iOS"
         ],
         "url": "https://www.xabber.com"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "xmpp",
+        "platforms": [
+            "Plan 9"
+        ],
+        "url": "https://git.sr.ht/~ft/xmpp"
     },
     {
         "categories": [
@@ -2001,6 +2088,17 @@
             "Ruby"
         ],
         "url": "https://github.com/blaine/xmpp4r-simple"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "xmppc",
+        "platforms": [
+            "Linux"
+        ],
+        "url": "https://codeberg.org/Anoxinon_e.V./xmppc"
     },
     {
         "categories": [

--- a/data/software.json
+++ b/data/software.json
@@ -1870,11 +1870,11 @@
             "library"
         ],
         "doap": null,
-        "name": "Ubeity",
+        "name": "Ubiety XMPP Core",
         "platforms": [
             "C#"
         ],
-        "url": "https://github.com/ubiety/xmpp"
+        "url": "https://github.com/ubiety/Ubiety.Xmpp.Core"
     },
     {
         "categories": [

--- a/data/software.json
+++ b/data/software.json
@@ -185,6 +185,7 @@
         "doap": null,
         "name": "BitlBee",
         "platforms": [
+            "BSD",
             "Linux"
         ],
         "url": "https://www.bitlbee.org"
@@ -604,6 +605,7 @@
         "doap": null,
         "name": "GNU Freetalk",
         "platforms": [
+            "BSD",
             "Linux"
         ],
         "url": "https://gnufreetalk.github.io/"
@@ -1154,7 +1156,9 @@
         "doap": null,
         "name": "mcabber",
         "platforms": [
-            "Other"
+            "BSD",
+            "Linux",
+            "macOS"
         ],
         "url": "https://mcabber.com"
     },
@@ -1246,6 +1250,7 @@
         "doap": null,
         "name": "Mozilla Thunderbird",
         "platforms": [
+            "BSD",
             "Linux",
             "macOS",
             "Windows"
@@ -1662,6 +1667,7 @@
         "doap": null,
         "name": "Smuxi",
         "platforms": [
+            "FreeBSD",
             "Linux",
             "macOS",
             "Windows"
@@ -2020,7 +2026,9 @@
         ],
         "doap": null,
         "name": "XMPP Status Checker",
-        "platforms": [],
+        "platforms": [
+            "Browser"
+        ],
         "url": "https://connect.xmpp.net/"
     },
     {

--- a/data/software.json
+++ b/data/software.json
@@ -389,28 +389,6 @@
         "categories": [
             "client"
         ],
-        "doap": null,
-        "name": "Coversant SoapBox Communicator",
-        "platforms": [
-            "Windows"
-        ],
-        "url": "http://coversant.com"
-    },
-    {
-        "categories": [
-            "server"
-        ],
-        "doap": null,
-        "name": "Coversant SoapBox Server",
-        "platforms": [
-            "Windows"
-        ],
-        "url": "http://coversant.com"
-    },
-    {
-        "categories": [
-            "client"
-        ],
         "doap": "https://raw.githubusercontent.com/dino/dino/master/dino.doap",
         "name": "Dino",
         "platforms": [],
@@ -699,27 +677,6 @@
     },
     {
         "categories": [
-            "tool"
-        ],
-        "doap": null,
-        "name": "IM Observatory",
-        "platforms": [],
-        "url": null
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": null,
-        "name": "IM+",
-        "platforms": [
-            "iOS",
-            "macOS"
-        ],
-        "url": "https://www.shape.ag/en/"
-    },
-    {
-        "categories": [
             "server"
         ],
         "doap": null,
@@ -795,17 +752,6 @@
         "name": "Isode M-Link",
         "platforms": [],
         "url": null
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "Jabber Stream Objects (JSO)",
-        "platforms": [
-            "Java"
-        ],
-        "url": "https://java.net/projects/jso"
     },
     {
         "categories": [
@@ -891,19 +837,6 @@
     },
     {
         "categories": [
-            "client"
-        ],
-        "doap": null,
-        "name": "Jabbim",
-        "platforms": [
-            "Linux",
-            "macOS",
-            "Windows"
-        ],
-        "url": "https://www.jabbim.com"
-    },
-    {
-        "categories": [
             "server"
         ],
         "doap": null,
@@ -955,18 +888,6 @@
         "name": "JaXMPP",
         "platforms": [],
         "url": null
-    },
-    {
-        "categories": [
-            "server"
-        ],
-        "doap": null,
-        "name": "Jerry Messenger",
-        "platforms": [
-            "Linux",
-            "Windows"
-        ],
-        "url": "http://j-livesupport.com"
     },
     {
         "categories": [
@@ -1067,17 +988,6 @@
             "Linux"
         ],
         "url": "https://userbase.kde.org/Kopete"
-    },
-    {
-        "categories": [
-            "server"
-        ],
-        "doap": null,
-        "name": "Kwickserver",
-        "platforms": [
-            "Windows"
-        ],
-        "url": "http://www.kwickserver.info/cms/"
     },
     {
         "categories": [
@@ -1282,17 +1192,6 @@
             "library"
         ],
         "doap": null,
-        "name": "oajabber",
-        "platforms": [
-            "C++"
-        ],
-        "url": null
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
         "name": "ObjXMPP",
         "platforms": [
             "Objective-C"
@@ -1469,17 +1368,6 @@
         "name": "P\u00e0d\u00e9",
         "platforms": [],
         "url": null
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": null,
-        "name": "Quiet Internet Pager",
-        "platforms": [
-            "Windows"
-        ],
-        "url": "http://forum.qip.ru"
     },
     {
         "categories": [
@@ -1773,17 +1661,6 @@
         "name": "Swiften",
         "platforms": [],
         "url": null
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": null,
-        "name": "Talkonaut",
-        "platforms": [
-            "Mobile"
-        ],
-        "url": "http://talkonaut.com"
     },
     {
         "categories": [


### PR DESCRIPTION
* Set proper names for XMPPFramework and XMPPHP.
* Add a website for net::XMPP.
* Fix platforms (supported OSes) for some clients, namely mention BSD.
* Replace unmaintained [Ubiety](https://github.com/ubiety/xmpp) library with it's successor, [Ubiety XMPP Core](https://github.com/ubiety/Ubiety.Xmpp.Core) library of the same author.
* Clean up the list. Coversant SoapBox Communicator/Server, Jabber Stream Objects, Jabbim (PyQt XMPP client, not to be confused with Jabbim XMPP provider), Jerry Messenger, Kwickserver, oajabber, Quiet Internet Pager, Talkonaut: completely gone, no website, no repository, no nothing. IM Observatory: [discontinued](https://xmpp.net/directory.php) since 2022. IM+: no longer offers XMPP support, according to [official website](https://plus.im).
* Add [BombusMod](https://github.com/BombusMod/BombusMod), [xmppc](https://codeberg.org/Anoxinon_e.V./xmppc), [Jackline](https://github.com/hannesm/jackline), [xmpp](https://git.sr.ht/~ft/xmpp) (for Plan 9), [Vacuum-IM](https://github.com/vacuum-im/vacuum-im), [Kontalk](https://www.kontalk.org), [JabberCat](https://jabbercat.org), [CoyIM](https://coy.im) clients.