### PR TITLE
Add Convo XMPP client

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -393,6 +393,15 @@
         "url": null
     },
     {
+      "name": "Convo",
+      "doap": "https://git.disroot.org/badrihippo/convo/raw/branch/master/convo.doap",
+      "platforms": [],
+      "url": null,
+      "categories": [
+        "client"
+      ]
+    },
+    {
         "categories": [
             "client"
         ],


### PR DESCRIPTION
It's a new XMPP client I made for KaiOS feature phones (the type with buttons) which uses ConverseJS as the backend.

I've set `<os>` in the DOAP record as `KaiOS`, which is not an existing category on the XMPP website, but I'm hoping that'd be handled automatically? The DOAP schema lists `<os>` as something to be represented literally, and as it's for a specific kind of device there was no existing option that fit.