### PR TITLE
Update Overview

### DIFF
--- a/content/about/technology-overview.md
+++ b/content/about/technology-overview.md
@@ -11,7 +11,7 @@ XMPP was originally developed in the Jabber open-source community to provide an 
 
 - **Open** — the XMPP protocols are free, open, public, and easily understandable; in addition, multiple implementations exist in the form of clients, servers, server components, and code libraries.
 
-- **Standard** — the [Internet Engineering Task Force (IETF)](http://www.ietf.org/) has formalized the core XML streaming protocols as an approved instant messaging and presence technology. The XMPP specifications were published as [RFC 3920](/rfcs#3920) and [RFC 3921](/rfcs#3921) in 2004, and the XMPP Standards Foundation continues to publish many [XMPP Extension Protocols](/extensions/). In 2011 the core RFCs were revised, resulting in the most up-to-date specifications ([RFC 6120](/rfcs#6120), [RFC 6121](/rfcs#6121), and [RFC 7622](/rfcs#7622)).
+- **Standard** — the [Internet Engineering Task Force (IETF)](https://www.ietf.org/) has formalized the core XML streaming protocols as an approved instant messaging and presence technology. The XMPP specifications were published as [RFC 3920](/rfcs#3920) and [RFC 3921](/rfcs#3921) in 2004, and the XMPP Standards Foundation continues to publish many [XMPP Extension Protocols](/extensions/). In 2011 the core RFCs were revised, resulting in the most up-to-date specifications ([RFC 6120](/rfcs#6120), [RFC 6121](/rfcs#6121), and [RFC 7622](/rfcs#7622)).
 
 - **Proven** — the first Jabber/XMPP technologies were developed by Jeremie Miller in 1998 and are now quite stable; hundreds of developers are working on these technologies, there are tens of thousands of XMPP servers running on the Internet today, and millions of people use XMPP for instant messaging through various public services and XMPP deployments at organizations worldwide.
 
@@ -39,7 +39,7 @@ Furthermore, we would like to suggest the independent [Modern XMPP project](http
 
 ## Core{#core}
 
-At its core, XMPP is a technology for streaming XML over a network. The protocol, which emerged from the Jabber open-source community in 1999, was originally designed to provide an open, secure, decentralized alternative to consumer-oriented instant messaging (IM) services like ICQ, AIM, and MSN. The core technologies were formalized under the name Extensible Messaging and Presence Protocol (XMPP) at the [IETF](http://www.ietf.org/) in 2004. These core technologies include:
+At its core, XMPP is a technology for streaming XML over a network. The protocol, which emerged from the Jabber open-source community in 1999, was originally designed to provide an open, secure, decentralized alternative to consumer-oriented instant messaging (IM) services like ICQ, AIM, and MSN. The core technologies were formalized under the name Extensible Messaging and Presence Protocol (XMPP) at the [IETF](https://www.ietf.org/) in 2004. These core technologies include:
 
 - The base XML streaming layer
 - Channel encryption using Transport Layer Security (TLS)
@@ -84,13 +84,13 @@ _Note: Many of the following implementations support the older Google Talk proto
 __Clients__
 
 - [Coccinella](http://coccinella.im/)
-- [Gajim](http://www.gajim.org/)
-- [Jitsi (formerly named SIP Communicator)](http://jitsi.org/)
+- [Gajim](https://gajim.org/)
+- [Jitsi](http://jitsi.org/)
 - [Movim](https://movim.eu)
 - [Pandion](http://pandion.im/)
-- [Pidgin (formerly named Gaim)](http://pidgin.im/)
-- [Psi](http://psi-im.org/)
-- [Telepathy](http://telepathy.freedesktop.org/)
+- [Pidgin](https://pidgin.im/)
+- [Psi](https://psi-im.org/)
+- [Telepathy](https://telepathy.freedesktop.org/)
 - [Yate](http://yate.null.ro/)
 
 __Libraries__
@@ -103,7 +103,7 @@ __Libraries__
 __Call Managers / VoIP Servers__
 
 - [Asterisk](http://www.asterisk.org/)
-- [FreeSWITCH](http://freeswitch.org/)
+- [FreeSWITCH](https://signalwire.com/freeswitch)
 - [Yate](http://yate.null.ro/)
 
 
@@ -123,13 +123,13 @@ MUC is defined in one primary specification (XEP-0045) and several ancillary spe
 
 __Servers__ - the following XMPP servers include built-in support for MUC:
 
-- [ejabberd](http://www.ejabberd.im/)
+- [ejabberd](https://www.ejabberd.im/)
 - [Jabber XCP](http://www.jabber.com/)
 - [M-Link](http://www.isode.com/products/m-link.html)
 - [MongooseIM](https://github.com/esl/MongooseIM)
 - [Openfire](http://www.igniterealtime.org/projects/openfire/index.jsp)
-- [Prosody](http://prosody.im/)
-- [Tigase](http://www.tigase.org/)
+- [Prosody](https://prosody.im/)
+- [Tigase](https://tigase.org/)
 
 __External Components__ - the following standalone components can be used with a wide variety of XMPP servers:
 
@@ -138,20 +138,20 @@ __External Components__ - the following standalone components can be used with a
 
 __Clients__
 
-- [Adium](http://adiumx.com/)
-- [Gajim](http://gajim.org/)
+- [Adium](https://adium.im/)
+- [Gajim](https://gajim.org/)
 - [JWChat](http://blog.jwchat.org/jwchat/)
-- [mcabber](http://mcabber.com/)
+- [mcabber](https://mcabber.com/)
 - [Movim](https://movim.eu)
-- [Pidgin](http://pidgin.im/)
-- [Psi](http://www.psi-im.org/)
+- [Pidgin](https://pidgin.im/)
+- [Psi](https://psi-im.org/)
 
 __Libraries__
 
 - [AnyEvent:XMPP](http://www.ta-sa.org/projects/anyevent_xmpp.html) (Perl)
-- [gloox](http://camaya.net/gloox) (C++)
-- [jabber-net](http://code.google.com/p/jabber-net/) (.Net)
-- [libpurple](http://developer.pidgin.im/wiki/WhatIsLibpurple) (C)
+- [gloox](https://camaya.net/gloox) (C++)
+- [jabber-net](https://code.google.com/archive/p/jabber-net/) (.Net)
+- [libpurple](https://developer.pidgin.im/wiki/WhatIsLibpurple) (C)
 - [Smack](http://www.igniterealtime.org/projects/smack/index.jsp) (Java)
 - [XMPP4R](http://home.gna.org/xmpp4r/) (Ruby)
 
@@ -185,11 +185,11 @@ PubSub and PEP are “payload-agnostic” — you can use them as neutral transp
 
 __Servers__ - the following XMPP servers include built-in support for PubSub or PEP:
 
-- [ejabberd](http://www.ejabberd.im/)
+- [ejabberd](https://www.ejabberd.im/)
 - [Jabber XCP](http://www.jabber.com/)
 - [M-Link](http://www.isode.com/products/m-link.html)
 - [Openfire](http://www.igniterealtime.org/projects/openfire/index.jsp)
-- [Tigase](http://www.tigase.org/)
+- [Tigase](https://tigase.org/)
 
 __Server Components__
 
@@ -197,9 +197,9 @@ __Server Components__
 
 __Clients__
 
-- [Gajim](http://gajim.org/)
+- [Gajim](https://gajim.org/)
 - [Movim](https://movim.eu)
-- [Psi](http://psi-im.org/)
+- [Psi](https://psi-im.org/)
 
 __3.4 Libraries__
 
@@ -219,13 +219,13 @@ BOSH is “Bidirectional-streams Over Synchronous HTTP”, a technology for two-
 
 Servers The following XMPP servers include built-in support for BOSH:
 
-- [ejabberd](http://www.ejabberd.im/)
+- [ejabberd](https://www.ejabberd.im/)
 - [Jabber XCP](http://www.jabber.com/)
 - [M-Link](http://www.isode.com/products/m-link.html)
 - [MongooseIM](https://github.com/esl/MongooseIM)
 - [Openfire](http://www.igniterealtime.org/projects/openfire/index.jsp)
-- [Prosody](http://prosody.im/)
-- [Tigase](http://www.tigase.org/)
+- [Prosody](https://prosody.im/)
+- [Tigase](https://tigase.org/)
 
 #### Connection Managers
 
@@ -233,29 +233,29 @@ The following standalone XMPP connection managers can be used with a wide variet
 
 - [JabberHTTPBind](http://blog.jwchat.org/jhb/)
 - [Punjab](http://code.stanziq.com/punjab)
-- [node-xmpp-bosh](https://github.com/dhruvbird/node-xmpp-bosh)
+- [node-xmpp-bosh](https://github.com/xmppo/node-xmpp-bosh)
 - [rhb](http://rubyforge.org/projects/rhb/)
 
 #### Clients
 
-- [Adium](http://adium.im/)
-- [Gajim](http://gajim.org/)
+- [Adium](https://adium.im/)
+- [Gajim](https://gajim.org/)
 - [JWChat](http://blog.jwchat.org/jwchat/)
-- [Pidgin](http://pidgin.im/)
+- [Pidgin](https://pidgin.im/)
 - [Soashable](http://www.soashable.com/)
 - [SparkWeb](http://www.igniterealtime.org/projects/sparkweb/)
-- [Swift](http://swift.im/swift/)
+- [Swift](https://swift.im/swift.html)
 - [Tigase Messenger](http://www.tigase.org/project/messenger)
 - [Tigase Minichat](http://www.tigase.org/project/minichat)
 
 #### Libraries
 
-- [emite](http://code.google.com/p/emite/) (gwt)
-- [gloox](http://camaya.net/gloox) (C++)
+- [emite](https://github.com/EmiteGWT/emite) (gwt)
+- [gloox](https://camaya.net/gloox) (C++)
 - [JSJaC](http://blog.jwchat.org/jsjac/) (JavaScript)
 - [strophe](http://code.stanziq.com/strophe/) (C or JavaScript)
-- [Swiften](http://swift.im/swiften/) (C++)
+- [Swiften](https://swift.im/swiften.html) (C++)
 - [XIFF](http://www.igniterealtime.org/projects/xiff/) (Flash)
 - [XMPP4GWT](http://www.tigase.org/project/xmpp4gwt) (gwt)
-- [xmpp4js](http://xmpp4js.sourceforge.net/index.html) (JavaScript)
+- [xmpp4js](https://xmpp4js.sourceforge.net/index.html) (JavaScript)
 - [XMPP4R](http://home.gna.org/xmpp4r/) (Ruby)


### PR DESCRIPTION
- Update some links.
- Remove ancient and irrelevant names of Pidgin and Jitsi.

There is a lot of unmaintained, severely outdated software on this page: Pandion, Soashable, SparkWeb, etc. Would it be better to move such projects to the "Other Software" section?