### PR TITLE
Draft: 2024 Annual Meeting and Voting Results

### DIFF
--- a/content/blog/2024-xsf-board-and-tech-council.md
+++ b/content/blog/2024-xsf-board-and-tech-council.md
@@ -5,9 +5,9 @@ author: nemmig
 categories: ["XSF Organisational"]
 ---
 
-Every year the members of the XSF get together to vote on the current quarter's new and renewing members and to also elect who will become members of the XMPP Council and who will server on the Board of Directors.
+Every year the members of the [XSF](https://xmpp.org/about/xmpp-standards-foundation/) get together to vote on the current quarter's new and renewing members and to also elect who will become members of the XMPP Council and who will server on the Board of Directors.
 
-This year that meeting was held on November 21th, 2024 and Alexander has recorded the details on the [XSF Wiki](https://wiki.xmpp.org/web/Meeting-Minutes-2024-11-21)
+This year that meeting was held on November 21st, 2024 and Alexander recorded the details on the [XSF Wiki](https://wiki.xmpp.org/web/Meeting-Minutes-2024-11-21)
 
 The XMPP [Council](https://xmpp.org/about/xmpp-standards-foundation/#council) for the 2024/2025 term will be integrated by:
 

--- a/content/blog/2024-xsf-board-and-tech-council.md
+++ b/content/blog/2024-xsf-board-and-tech-council.md
@@ -5,24 +5,23 @@ author: nemmig
 categories: ["XSF Organisational"]
 ---
 
-Every year the members of the [XSF](https://xmpp.org/about/xmpp-standards-foundation/) get together to vote on the current quarter's new and renewing members and to also elect who will become members of the XMPP Council and who will server on the Board of Directors.
+Every year the members of the [XSF](https://xmpp.org/about/xmpp-standards-foundation/) get together to vote on the current quarter's [new and renewing members](/community/membership/). Additionally, elections for both XMPP Council and Board of Directors have been held.
 
-This year that meeting was held on November 21st, 2024 and Alexander recorded the details on the [XSF Wiki](https://wiki.xmpp.org/web/Meeting-Minutes-2024-11-21)
+This year's election meeting was held on November 21st, 2024 and voting results can be found in the [XSF Wiki](https://wiki.xmpp.org/web/Meeting-Minutes-2024-11-21).
 
-The XMPP [Council](https://xmpp.org/about/xmpp-standards-foundation/#council) for the 2024/2025 term will be integrated by:
+The 2024/2025 term will be formed by the following members:
 
-- Dan Caseley
-- Daniel Gultsch
-- Jérôme Poisson
-- Stephen Paul Weber
-- Marvin Wißfeld
+- XMPP [Council](https://xmpp.org/about/xmpp-standards-foundation/#council)
+  - Dan Caseley
+  - Daniel Gultsch
+  - Jérôme Poisson
+  - Stephen Paul Weber
+  - Marvin Wißfeld
+- [Board of Directors](https://xmpp.org/about/xmpp-standards-foundation/#board)
+  - Edward Maurer
+  - Ralph Meijer
+  - Florian Schmaus
+  - Dave Cridland
+  - Arne-Bruen Vogelsang
 
-The [Board of Directors](https://xmpp.org/about/xmpp-standards-foundation/#board) for the 2024/2025 term will be integrated by:
-
-- Edward Maurer
-- Ralph Meijer
-- Florian Schmaus
-- Dave Cridland
-- Arne-Bruen Vogelsang
-
-Please congratulate them if you run across any of them, but also please help us make this another great year for the XSF.
+Please congratulate them if you run across any of those listed here, but also please help us make this another great year for the XSF.

--- a/content/blog/2024-xsf-board-and-tech-council.md
+++ b/content/blog/2024-xsf-board-and-tech-council.md
@@ -1,0 +1,28 @@
+---
+title: 2024 Annual Meeting and Voting Results
+date: 2024-11-21
+author: nemmig
+categories: ["XSF Organisational"]
+---
+
+Every year the members of the XSF get together to vote on the current quarter's new and renewing members and to also elect who will become members of the XMPP Council and who will server on the Board of Directors.
+
+This year that meeting was held on November 21th, 2024 and Alexander has recorded the details on the [XSF Wiki](https://wiki.xmpp.org/web/Meeting-Minutes-2024-11-21)
+
+The XMPP Council for the 2024/2025 term will be integrated by:
+
+- Dan Caseley
+- Daniel Gultsch
+- Jérôme Poisson
+- Stephen Paul Weber
+- Marvin Wißfeld
+
+The Board of Directors for the 2024/2025 term will be integrated by:
+
+- Edward Maurer
+- Ralph Meijer
+- Florian Schmaus
+- Dave Cridland
+- Arne-Bruen Vogelsang
+
+Please congratulate them if you run across any of them, but also please help us make this another great year for the XSF.

--- a/content/blog/2024-xsf-board-and-tech-council.md
+++ b/content/blog/2024-xsf-board-and-tech-council.md
@@ -9,7 +9,7 @@ Every year the members of the XSF get together to vote on the current quarter's 
 
 This year that meeting was held on November 21th, 2024 and Alexander has recorded the details on the [XSF Wiki](https://wiki.xmpp.org/web/Meeting-Minutes-2024-11-21)
 
-The XMPP Council for the 2024/2025 term will be integrated by:
+The XMPP [Council](https://xmpp.org/about/xmpp-standards-foundation/#council) for the 2024/2025 term will be integrated by:
 
 - Dan Caseley
 - Daniel Gultsch
@@ -17,7 +17,7 @@ The XMPP Council for the 2024/2025 term will be integrated by:
 - Stephen Paul Weber
 - Marvin Wißfeld
 
-The Board of Directors for the 2024/2025 term will be integrated by:
+The [Board of Directors](https://xmpp.org/about/xmpp-standards-foundation/#board) for the 2024/2025 term will be integrated by:
 
 - Edward Maurer
 - Ralph Meijer


### PR DESCRIPTION
This PR creates a new blog entry to inform the community about the outcome of the 2024 Annual Meeting and Voting Results (held on 2024-11-21) and the names of the XSF members that will serve on the XMPP Council and Board of Directors during the 2024/2025 term. 