### PR TITLE
Extensions: Show <supersededby> specs in extension table

### DIFF
--- a/themes/xmpp.org/layouts/shortcodes/xeps-table.html
+++ b/themes/xmpp.org/layouts/shortcodes/xeps-table.html
@@ -106,6 +106,7 @@
             </thead>
             <tbody>
                 {{- if .Site.Data.xeplist -}}
+                    {{- $xeplist := .Site.Data.xeplist -}}
                     {{- range sort .Site.Data.xeplist ".number" -}}
                         {{- $number_str := printf "%04g" .number -}}
                         {{ $last_revision_date := .last_revision_date | time }}
@@ -118,10 +119,36 @@
 
                         <tr class="XEP-{{ .status }} {{ if $xep_dormant }} XEP-Dormant{{ end }}" id="xep{{- $number_str -}}" data-shortname="{{- .shortname -}}">
                             <td><a href="/extensions/xep-{{- $number_str -}}.html">XEP-{{- $number_str -}}</a></td>
-                            <td>{{- .title -}}</td>
-                            <td>{{- .type -}}</td>
-                            <td>{{- .status -}}</td>
-                            <td>{{- .last_revision_date -}}</td>
+                            <td>
+                                {{- .title -}}
+                                {{- if .supersededby -}}
+                                    <br>
+                                    <span class="text-muted small">Superseded by:&nbsp;</span>
+                                    <span class="text-muted small">
+                                        {{- range $index, $content := .supersededby -}}
+                                            {{- if $index -}}
+                                                ,&nbsp;
+                                            {{- end -}}
+                                            {{- if hasPrefix (. | lower) "xep-" -}}
+                                                {{- $xep_number := int (trim (. | lower) "xep-" | replaceRE "^0+" "") -}}
+                                                {{- $spec := . -}}
+                                                {{- range $xeplist -}}
+                                                    {{- if eq (int .number) $xep_number -}}
+                                                        <a href="/extensions/{{- $spec | lower -}}.html">{{- print ($spec | upper) ": " .title -}}</a>
+                                                    {{- end -}}
+                                                {{- end -}}
+                                            {{- else if hasPrefix (. | lower) "rfc" -}}
+                                                <a href="https://datatracker.ietf.org/doc/{{- replaceRE "(\\s)" "" . | lower -}}/" target="_blank">{{ print "RFC " (index (findRE `\d{4}` . 1) 0) }}</a>
+                                            {{- else -}}
+                                                <span>{{- . -}}</span>
+                                            {{- end -}}
+                                        {{- end -}}
+                                    </span>
+                                {{- end -}}
+                            </td>
+                            <td class="text-nowrap">{{- .type -}}</td>
+                            <td class="text-nowrap">{{- .status -}}</td>
+                            <td class="text-nowrap">{{- .last_revision_date -}}</td>
                             <td>
                                 {{- range .tags -}}
                                     <span class="badge rounded-pill text-bg-secondary mx-1">{{- . -}}</span>

--- a/tools/prepare_xep_list.py
+++ b/tools/prepare_xep_list.py
@@ -68,6 +68,20 @@ def build_xep_list() -> None:
                 if tag.text is not None:
                     tag_list.append(tag.text)  # noqa: PERF401
 
+        supersedes_list: list[str] = []
+        supersedes = xep.find("supersedes")
+        if supersedes is not None:
+            for spec in supersedes.findall("spec"):
+                if spec.text is not None:
+                    supersedes_list.append(spec.text)  # noqa: PERF401
+
+        supersededby_list: list[str] = []
+        supersededby = xep.find("supersededby")
+        if supersededby is not None:
+            for spec in supersededby.findall("spec"):
+                if spec.text is not None:
+                    supersededby_list.append(spec.text)  # noqa: PERF401
+
         date = None
         version = None
         initials = None
@@ -100,6 +114,8 @@ def build_xep_list() -> None:
                 "type": xep_type,
                 "abstract": abstract,
                 "tags": tag_list,
+                "supersedes": supersedes_list,
+                "supersededby": supersededby_list,
             },
         )
     xeps_sorted = sorted(xeps, key=lambda xep: xep["number"])


### PR DESCRIPTION
This adds a button with a popover for all XEP in https://xmpp.org/extensions which have a `<supersededby>` tag set. 

All `<spec>` elements within the `<supersededby>` are rendered inside the popover. 

If possible, specs are transformed to an HTML link (for XEPs and RFCs).

Depends on xsf/xeps#1418

Example:
![image](https://github.com/user-attachments/assets/cafdc8a5-cee1-49cf-8430-94a90a0a1ca2)

@iNPUTmice 
