### PR TITLE
text-nowrap on subscribe/archives links for mailinglists

### DIFF
--- a/content/community/mailing-lists.md
+++ b/content/community/mailing-lists.md
@@ -9,19 +9,19 @@ There are many active discussion venues for Jabber/XMPP developers, system admin
 
 ### For End Users
 
-__JUser@jabber.org email list__ — for discussion about use of IM clients ([subscribe](https://mail.jabber.org/mailman/listinfo/juser) | [archives](https://mail.jabber.org/pipermail/juser/))
+__JUser@jabber.org email list__ — for discussion about use of IM clients {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/juser" archive="https://mail.jabber.org/pipermail/juser/" >}}
 
 ### For System Admins
 
-__Operators@xmpp.org email list__ — for discussion about day-to-day operation of the Jabber/XMPP communications network ([subscribe](https://mail.jabber.org/mailman/listinfo/operators) | [archives](https://mail.jabber.org/pipermail/operators/))
+__Operators@xmpp.org email list__ — for discussion about day-to-day operation of the Jabber/XMPP communications network {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/operators" archive="https://mail.jabber.org/pipermail/operators/" >}}
 
 ### For Developers
 
-__JDev@jabber.org email list__ — for discussion about software development using Jabber/XMPP technologies ([subscribe](https://mail.jabber.org/mailman/listinfo/jdev) | [archives](https://mail.jabber.org/pipermail/jdev/))
+__JDev@jabber.org email list__ — for discussion about software development using Jabber/XMPP technologies {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/jdev" archive="https://mail.jabber.org/pipermail/jdev/" >}}
 
-__Standards@xmpp.org email list__ — for general discussion about XMPP protocols ([subscribe](https://mail.jabber.org/mailman/listinfo/standards) | [archives](https://mail.jabber.org/pipermail/standards/))
+__Standards@xmpp.org email list__ — for general discussion about XMPP protocols {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/standards" archive="https://mail.jabber.org/pipermail/standards/" >}}
 
-__xmpp@ietf.org email list__ — official list for [XMPP Working Group](http://tools.ietf.org/wg/xmpp/) discussions at the [IETF](http://www.ietf.org/) ([subscribe](https://www.ietf.org/mailman/listinfo/xmpp) | [archives](http://www.ietf.org/mail-archive/web/xmpp/current/maillist.html))
+__xmpp@ietf.org email list__ — official list for [XMPP Working Group](http://tools.ietf.org/wg/xmpp/) discussions at the [IETF](http://www.ietf.org/) {{< subscribe-archive-block subscribe="https://www.ietf.org/mailman/listinfo/xmpp" archive="http://www.ietf.org/mail-archive/web/xmpp/current/maillist.html" >}}
 
 ### For Members
 
@@ -31,8 +31,8 @@ __Members@xmpp.org email list__ — official list for members of the XSF. Subscr
 
 The following special-purpose mailing lists provide low-volume, high-quality discussion among developers interested in specific aspects of XMPP technologies.
 
-__IOT@xmpp.org email list__ — for discussion about the use of XMPP in the Internet of Things ([subscribe](https://mail.jabber.org/mailman/listinfo/iot) | [archives](https://mail.jabber.org/pipermail/iot/))
+__IOT@xmpp.org email list__ — for discussion about the use of XMPP in the Internet of Things {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/iot" archive="https://mail.jabber.org/pipermail/iot/" >}}
 
-__Security@xmpp.org email list__ — for discussion about security issues related to XMPP, including encryption, authentication, and spam ([subscribe](https://mail.jabber.org/mailman/listinfo/security) | [archives](https://mail.jabber.org/pipermail/security/))
+__Security@xmpp.org email list__ — for discussion about security issues related to XMPP, including encryption, authentication, and spam {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/security" archive="https://mail.jabber.org/pipermail/security/" >}}
 
 All of these venues are completely free and open to any interested individual.

--- a/themes/xmpp.org/layouts/shortcodes/subscribe-archive-block.html
+++ b/themes/xmpp.org/layouts/shortcodes/subscribe-archive-block.html
@@ -1,0 +1,5 @@
+<span class="text-nowrap">
+    (<a href="{{- .Get "subscribe" -}}" target="_blank" class="icon-link">subscribe<i class="fa-solid fa-arrow-up-right-from-square fa-xs opacity-75 me-1"></i></a> 
+    |
+    <a href="{{- .Get "archives" -}}" target="_blank" class="icon-link">archives<i class="fa-solid fa-arrow-up-right-from-square fa-xs opacity-75 me-1"></i></a>)
+</span>


### PR DESCRIPTION
Introduces a shortcode for the block that contains the `(subscribe | archives)` links for each mailing list. This intends to prevent odd line-breakage within those blocks.

fixes #1478

Changes render as shown below:

![image](https://github.com/user-attachments/assets/43f155f3-b8e1-41ed-9905-ebd0da955e99)
