### PR TITLE
Fix links to mailing list archives

### DIFF
--- a/content/community/mailing-lists.md
+++ b/content/community/mailing-lists.md
@@ -9,19 +9,19 @@ There are many active discussion venues for Jabber/XMPP developers, system admin
 
 ### For End Users
 
-__JUser@jabber.org email list__ — for discussion about use of IM clients {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/juser" archive="https://mail.jabber.org/pipermail/juser/" >}}
+__JUser@jabber.org email list__ — for discussion about use of IM clients {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/juser" archives="https://mail.jabber.org/pipermail/juser/" >}}
 
 ### For System Admins
 
-__Operators@xmpp.org email list__ — for discussion about day-to-day operation of the Jabber/XMPP communications network {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/operators" archive="https://mail.jabber.org/pipermail/operators/" >}}
+__Operators@xmpp.org email list__ — for discussion about day-to-day operation of the Jabber/XMPP communications network {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/operators" archives="https://mail.jabber.org/pipermail/operators/" >}}
 
 ### For Developers
 
-__JDev@jabber.org email list__ — for discussion about software development using Jabber/XMPP technologies {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/jdev" archive="https://mail.jabber.org/pipermail/jdev/" >}}
+__JDev@jabber.org email list__ — for discussion about software development using Jabber/XMPP technologies {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/jdev" archives="https://mail.jabber.org/pipermail/jdev/" >}}
 
-__Standards@xmpp.org email list__ — for general discussion about XMPP protocols {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/standards" archive="https://mail.jabber.org/pipermail/standards/" >}}
+__Standards@xmpp.org email list__ — for general discussion about XMPP protocols {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/standards" archives="https://mail.jabber.org/pipermail/standards/" >}}
 
-__xmpp@ietf.org email list__ — official list for [XMPP Working Group](http://tools.ietf.org/wg/xmpp/) discussions at the [IETF](http://www.ietf.org/) {{< subscribe-archive-block subscribe="https://www.ietf.org/mailman/listinfo/xmpp" archive="http://www.ietf.org/mail-archive/web/xmpp/current/maillist.html" >}}
+__xmpp@ietf.org email list__ — official list for [XMPP Working Group](http://tools.ietf.org/wg/xmpp/) discussions at the [IETF](http://www.ietf.org/) {{< subscribe-archive-block subscribe="https://www.ietf.org/mailman/listinfo/xmpp" archives="http://www.ietf.org/mail-archive/web/xmpp/current/maillist.html" >}}
 
 ### For Members
 
@@ -31,8 +31,8 @@ __Members@xmpp.org email list__ — official list for members of the XSF. Subscr
 
 The following special-purpose mailing lists provide low-volume, high-quality discussion among developers interested in specific aspects of XMPP technologies.
 
-__IOT@xmpp.org email list__ — for discussion about the use of XMPP in the Internet of Things {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/iot" archive="https://mail.jabber.org/pipermail/iot/" >}}
+__IOT@xmpp.org email list__ — for discussion about the use of XMPP in the Internet of Things {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/iot" archives="https://mail.jabber.org/pipermail/iot/" >}}
 
-__Security@xmpp.org email list__ — for discussion about security issues related to XMPP, including encryption, authentication, and spam {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/security" archive="https://mail.jabber.org/pipermail/security/" >}}
+__Security@xmpp.org email list__ — for discussion about security issues related to XMPP, including encryption, authentication, and spam {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/security" archives="https://mail.jabber.org/pipermail/security/" >}}
 
 All of these venues are completely free and open to any interested individual.


### PR DESCRIPTION
Commit 428b2cad6b7cb5e167f9ebdf6e17c77691efe8bb introduced a typo, preventing the links to the archives of mailing lists to be correctly used.