### PR TITLE
Remove unmaintained blabber.im

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -188,15 +188,6 @@
     },
     {
         "categories": [
-            "client"
-        ],
-        "doap": "https://codeberg.org/kriztan/blabber.im/raw/branch/master/blabber.im.doap",
-        "name": "blabber.im",
-        "platforms": [],
-        "url": null
-    },
-    {
-        "categories": [
             "library"
         ],
         "doap": null,


### PR DESCRIPTION
Removes blabber.im, unmaintained [according to its author](https://codeberg.org/kriztan/blabber.im/commit/55842b6a0dfdf90f89940c340286d8173c013cc6),
and said to [contain unfixed security issues](https://gultsch.social/@daniel/113718247840154604)
