### PR TITLE
Software: Archive Blabber

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -188,15 +188,6 @@
     },
     {
         "categories": [
-            "client"
-        ],
-        "doap": "https://codeberg.org/kriztan/blabber.im/raw/branch/master/blabber.im.doap",
-        "name": "blabber.im",
-        "platforms": [],
-        "url": null
-    },
-    {
-        "categories": [
             "library"
         ],
         "doap": null,

--- a/data/software_archive.json
+++ b/data/software_archive.json
@@ -121,5 +121,14 @@
             "Mobile"
         ],
         "url": "http://talkonaut.com"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": "https://codeberg.org/kriztan/blabber.im/raw/branch/master/blabber.im.doap",
+        "name": "blabber.im",
+        "platforms": [],
+        "url": null
     }
 ]


### PR DESCRIPTION
It has been unmaintained since October 2022, and shouldn’t be recommended anymore.