### PR TITLE
first pass at 2024 financials and reporting format

### DIFF
--- a/content/about/xsf/financials.md
+++ b/content/about/xsf/financials.md
@@ -1,0 +1,35 @@
+---
+Title: XSF Financials
+Url: about/xsf/financials
+---
+
+This page, maintained by the XSF's Treasurer, provides high-level information about the income and expenses of the [XMPP Standards Foundation](/about/xsf/). Please note that this page is a work in progress and will be updated regularly to provide more complete insights. 
+
+Last Updated: 2025-02-10.
+
+## 2024
+
+In 2024, the XSF's income is estimated to have been as follows:
+
+| Income Type            | Amount    | Notes                                   |
+|------------------------|-----------|-----------------------------------------|
+| Corporate Sponsorships |  $6175.05 | Summit and regular sponsors             |
+| Google Summer of Code  |  $1000.00 |                                         |
+| Individual Donations   |  $1451.00 | Includes non-corporate Summit donations |
+| Open Collective        |   $850.15 | Contributions to projects we sponsor    |
+| TOTAL                  |  $9476.20 |                                         |
+
+NOTE: $5000 in sponsorships for the year 2024 were received in 2023.
+
+In 2024, the XSF's expenses are estimated to have been as follows:
+
+| Expense Type   | Amount    | Notes                                           |
+|----------------|-----------|-------------------------------------------------|
+| Conferences    | $11099.02 | XMPP Summit, FOSDEM, meetups, etc. (see note)   |
+| Infrastructure |   $690.92 | Digital Ocean, Tarsnap backups, etc.            |
+| Business Fees  |   $527.00 | Corporate registration, taxes, P.O. box, etc.   |
+| TOTAL          | $12316.94 |                                                 |
+
+NOTE: Because we pre-pay to reserve the meeting room, XMPP Summit expenses can be spread across two years (e.g., some costs for the Summit held in 2025 were paid in 2024).
+
+Previous years to follow, once we settle on the format and level of detail.


### PR DESCRIPTION
This web page is a stub for financial reporting by the Treasurer to the Board, XSF members, and the community more widely. Currently it includes only 2024 data (estimated). The format is also provisional while we determine what level of detail would be helpful to the Board. It would be good to merge this into HEAD so that the Treasurer can seek initial feedback from the Board. Once that is done, the Treasurer will update the 2024 report and add past years.