### PR TITLE
Delete the 2 direct links to XSF twitter posts, they have mastodon links too

### DIFF
--- a/content/blog/2022-05-28-gsoc2022-welcome.md
+++ b/content/blog/2022-05-28-gsoc2022-welcome.md
@@ -32,7 +32,6 @@ Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/10835882
 
 Checkout our media channels, too!
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 

--- a/content/blog/2022-05-28-gsoc2022-welcome.md
+++ b/content/blog/2022-05-28-gsoc2022-welcome.md
@@ -22,7 +22,7 @@ So, please welcome **Patiga** and **PawBud** as new contributors! It is really g
 - **PawBud** will work towards adding support for [A/V communication via Jingle in ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19). Mentors will be **JC Brand** and **vanitasvitae** - many thanks to both of you, too!
   - The idea is to add support for Audio & Video communication through the Jingle protocol. The goal is to create a Converse plugin that adds the ability to make one-on-one audio/video calls from Converse. The audio/video calls will be compatible with other XMPP clients.
 
-Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) or [Twitter](https://twitter.com/xmpp/status/1529199174729728000).
+Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966).
 
  ### Resources
 

--- a/content/blog/2023-04-17-elbe-sprint.md
+++ b/content/blog/2023-04-17-elbe-sprint.md
@@ -34,7 +34,7 @@ Adding yourself to the list will help us organise everything - thanks! If you do
 ### Chat & Communication
 
 It's recommended to join the chat and say hello if you are interested: [XMPP Chat](xmpp:sprints@joinjabber.org?join) & [WebChat](https://chat.joinjabber.org/#/guest?join=sprints)
-Feel free to share via [Mastodon](https://fosstodon.org/@xmpp/110214602731131770) or [Twitter](https://twitter.com/xmpp/status/1647968875877736451?cxt=HHwWhoC9-cK94d4tAAAA)!
+Feel free to share via [Mastodon](https://fosstodon.org/@xmpp/110214602731131770)!
 
 Looking forward to meet you,
 

--- a/content/blog/2024-01-04-fosdem2024.md
+++ b/content/blog/2024-01-04-fosdem2024.md
@@ -39,7 +39,6 @@ We'll be reporting live from the event and also from FOSDEM.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/2024-01-05-xmpp-summit-26.md
+++ b/content/blog/2024-01-05-xmpp-summit-26.md
@@ -46,7 +46,7 @@ Please also consider signing up if you plan to:
 
 To ensure you receive all the relevant information, updates and announcements about the event, make sure that you're signed up to the [Summit mailing list](https://mail.jabber.org/mailman/listinfo/summit) and the [Summit chatroom](xmpp:summit@muc.xmpp.org?join).
 
-Spread the word also via our communication channels such as [Mastodon](https://fosstodon.org/@xmpp) and [Twitter](https://twitter.com/xmpp).
+Spread the word also via our communication channels such as [Mastodon](https://fosstodon.org/@xmpp).
 
 ### Sponsors
 

--- a/content/blog/2024-11-05-xmpp-summit-27.md
+++ b/content/blog/2024-11-05-xmpp-summit-27.md
@@ -64,7 +64,7 @@ Please also consider signing up if you plan to:
 
 To ensure you receive all the relevant information, updates and announcements about the event, make sure that you're signed up to the [Summit mailing list](https://mail.jabber.org/mailman/listinfo/summit) and the [Summit chatroom](xmpp:summit@muc.xmpp.org?join) ([Webview](/chat#converse/room?jid=xsf@muc.xmpp.org)).
 
-Spread the word also via our communication channels such as [Mastodon](https://fosstodon.org/@xmpp) and [Twitter](https://twitter.com/xmpp).
+Spread the word also via our communication channels such as [Mastodon](https://fosstodon.org/@xmpp).
 
 ### Sponsors
 

--- a/content/blog/2025-01-10-fosdem2025.md
+++ b/content/blog/2025-01-10-fosdem2025.md
@@ -36,7 +36,6 @@ We'll be reporting live from the event and also from [FOSDEM](https://fosdem.org
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/google-summer-of-code-2023.md
+++ b/content/blog/google-summer-of-code-2023.md
@@ -25,7 +25,6 @@ We have further details and advertisement material on our designated web page pr
 
 Checkout our media channels!
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 

--- a/content/blog/newsletter/2019-10-01-newsletter.md
+++ b/content/blog/newsletter/2019-10-01-newsletter.md
@@ -110,7 +110,7 @@ URL: https://xmpp.org/extensions/inbox/auth-tokens.html
 
 This XMPP Newsletter is a community collaborative effort. Thanks to Nÿco, Daniel, Jwi, and MDosch for aggregating the news. Thanks Nÿco, Seve, Jwi, and Matt for the copywriting. Thanks Guus, Seve, Jonas for the reviews.
 
-Please follow and relay the XMPP news on our Twitter account [@xmpp](https://twitter.com/xmpp).
+Please follow and relay the XMPP news on our [Mastodon](https://fosstodon.org/@xmpp) account.
 
 ## License
 

--- a/content/blog/newsletter/2019-11-08-newsletter.md
+++ b/content/blog/newsletter/2019-11-08-newsletter.md
@@ -94,7 +94,7 @@ This XMPP Newsletter is produced collaboratively by the community.
 
 Thanks to Nyco, MDosch, Daniel, Guus, Link Mauve, and mwild1 for their help in creating it!
 
-Please follow our Twitter account [@xmpp](https://twitter.com/xmpp), and relay the XMPP news.
+Please follow our [Mastodon](https://fosstodon.org/@xmpp) account, and relay the XMPP news.
 
 ## License
 

--- a/content/blog/newsletter/2019-12-03-newsletter.md
+++ b/content/blog/newsletter/2019-12-03-newsletter.md
@@ -110,7 +110,6 @@ Thanks to Nyco, Guus, Wurstsalat, MDosch, Neustradamus, Ppjet6 for their help in
 
 Please share the news on "social networks":
 
-* Twitter: [https://twitter.com/xmpp](https://twitter.com/xmpp)
 * Mastodon: [https://fosstodon.org/@xmpp/](https://fosstodon.org/@xmpp/)
 * LinkedIn: [https://www.linkedin.com/company/xmpp-standards-foundation/](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * Facebook: [https://www.facebook.com/jabber/](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2020-01-10-newsletter.md
+++ b/content/blog/newsletter/2020-01-10-newsletter.md
@@ -155,7 +155,6 @@ Thanks to Wurstsalat, Echolon, Guus, MDosch for their help in creating it!
 
 Please share the news on "social networks":
 
-* Twitter: https://twitter.com/xmpp
 * Mastodon: https://fosstodon.org/@xmpp/
 * LinkedIn: https://www.linkedin.com/company/xmpp-standards-foundation/
 * Facebook: https://www.facebook.com/jabber/

--- a/content/blog/newsletter/2020-02-04-newsletter.md
+++ b/content/blog/newsletter/2020-02-04-newsletter.md
@@ -206,7 +206,6 @@ Thanks to MDosch, Vanitasvitae, Wurstsalat, Neustradamus, Jwi, geOrg, licaon-kte
 
 Please share the news on "social networks":
 
-* Twitter: https://twitter.com/xmpp
 * Mastodon: https://fosstodon.org/@xmpp/
 * LinkedIn: https://www.linkedin.com/company/xmpp-standards-foundation/
 * Facebook: https://www.facebook.com/jabber/

--- a/content/blog/newsletter/2020-03-15-newsletter.md
+++ b/content/blog/newsletter/2020-03-15-newsletter.md
@@ -231,7 +231,6 @@ Thanks to Aleja, emus, Licaon_Kter, MDosch, Neustradamus, Nyco, pep, Sven, Vanit
 
 Please share the news on "social networks":
 
-* Twitter: [twitter.com/xmpp](https://twitter.com/xmpp)
 * Mastodon: [fosstodon.org/@xmpp/](https://fosstodon.org/@xmpp/)
 * LinkedIn: [www.linkedin.com/company/xmpp-standards-foundation/](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * Facebook: [www.facebook.com/jabber/](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2020-04-02-newsletter.md
+++ b/content/blog/newsletter/2020-04-02-newsletter.md
@@ -140,7 +140,6 @@ Thanks to Aleja, emus, horazont, jcbrand, mdosch, pep., pmaziere, Sven, wurstsal
 
 Please share the news on "social networks":
 
-* Twitter: [https://twitter.com/xmpp](https://twitter.com/xmpp)
 * Mastodon: [https://fosstodon.org/@xmpp/](https://fosstodon.org/@xmpp/)
 * LinkedIn: [https://www.linkedin.com/company/xmpp-standards-foundation/](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * Facebook: [https://www.facebook.com/jabber/](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2020-06-09-newsletter.md
+++ b/content/blog/newsletter/2020-06-09-newsletter.md
@@ -179,7 +179,6 @@ Thanks to emus, nyco, pmaziere, SouL, vanitasvitae, wurstsalat3000 for their hel
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2020-07-01-newsletter.md
+++ b/content/blog/newsletter/2020-07-01-newsletter.md
@@ -156,7 +156,6 @@ Thanks to emus, mdosch, nyco, pep., pmaziere, sualko, vanitasvitae, wurstsalat30
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2020-08-06-newsletter.md
+++ b/content/blog/newsletter/2020-08-06-newsletter.md
@@ -166,7 +166,6 @@ Thanks to eta, emus, erszcz, Ge0rG, Holger, kriztan, jerome-poisson, jonas', Lic
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2020-08-08-newsletter.md
+++ b/content/blog/newsletter/2020-08-08-newsletter.md
@@ -161,7 +161,6 @@ Thanks to COM8, emus, jcbrand, jerome-poisson, jonas', Licaon_Kter, melvo, pmazi
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2020-09-06-newsletter.md
+++ b/content/blog/newsletter/2020-09-06-newsletter.md
@@ -101,7 +101,6 @@ Thanks to agnauck, emus, mdosch, mwild1, pep., pmaziere, Seve, wurstsalat3000 an
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2020-11-05-newsletter.md
+++ b/content/blog/newsletter/2020-11-05-newsletter.md
@@ -136,7 +136,6 @@ Thanks to edhelas, emus, erszcz, guusdk, licaon-kter, mwild1 and wurstsalat3000 
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2020-12-09-newsletter.md
+++ b/content/blog/newsletter/2020-12-09-newsletter.md
@@ -171,7 +171,6 @@ See you in the next year, stay safe!
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2021-02-05-newsletter.md
+++ b/content/blog/newsletter/2021-02-05-newsletter.md
@@ -205,7 +205,6 @@ See you in the next year, stay safe!
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2021-03-05-newsletter.md
+++ b/content/blog/newsletter/2021-03-05-newsletter.md
@@ -151,7 +151,6 @@ Thanks to wurstsalat3000, Sam Whited, pitchum, Licaon_Kter, jeybe and emus for t
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2021-04-05-newsletter.md
+++ b/content/blog/newsletter/2021-04-05-newsletter.md
@@ -134,7 +134,6 @@ Thanks to anubis, Bastoon, emus, jeybe, jonas-l, Julien Jorge, Holger, pmaziere,
 
 Please share the news on "social networks":
 
-* [Twitter](https://twitter.com/xmpp)
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)

--- a/content/blog/newsletter/2021-05-05-newsletter.md
+++ b/content/blog/newsletter/2021-05-05-newsletter.md
@@ -163,7 +163,6 @@ Please share the news on "social networks":
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2021-06-05-newsletter.md
+++ b/content/blog/newsletter/2021-06-05-newsletter.md
@@ -149,7 +149,6 @@ Please share the news on "social networks":
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2021-07-05-newsletter.md
+++ b/content/blog/newsletter/2021-07-05-newsletter.md
@@ -166,7 +166,6 @@ Please share the news on "social networks":
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Facebook](https://www.facebook.com/jabber/)

--- a/content/blog/newsletter/2021-08-05-newsletter.md
+++ b/content/blog/newsletter/2021-08-05-newsletter.md
@@ -186,7 +186,6 @@ Please share the news via other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2021-09-05-newsletter.md
+++ b/content/blog/newsletter/2021-09-05-newsletter.md
@@ -157,7 +157,6 @@ Please share the news via other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2021-10-05-newsletter.md
+++ b/content/blog/newsletter/2021-10-05-newsletter.md
@@ -151,7 +151,6 @@ Please share the news via other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2021-11-05-newsletter.md
+++ b/content/blog/newsletter/2021-11-05-newsletter.md
@@ -174,7 +174,6 @@ Please share the news via other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2021-12-05-newsletter.md
+++ b/content/blog/newsletter/2021-12-05-newsletter.md
@@ -165,7 +165,6 @@ Please share the news via other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2022-02-05-newsletter.de.md
+++ b/content/blog/newsletter/2022-02-05-newsletter.de.md
@@ -207,7 +207,6 @@ Teile unsere Neuigkeiten in "Sozialen Netzwerken":
 
 * [Mastodon](https://fosstodon.org/@xmpp/) [EN]
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA) [EN]
-* [Twitter](https://twitter.com/xmpp) [EN]
 * [Reddit](https://www.reddit.com/r/xmpp/) [EN]
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/) [EN]
 

--- a/content/blog/newsletter/2022-02-05-newsletter.es.md
+++ b/content/blog/newsletter/2022-02-05-newsletter.es.md
@@ -202,7 +202,6 @@ Por favor, comparte la noticia a través de otras redes:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2022-02-05-newsletter.md
+++ b/content/blog/newsletter/2022-02-05-newsletter.md
@@ -207,7 +207,6 @@ Please share the news via other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2022-03-05-newsletter.de.md
+++ b/content/blog/newsletter/2022-03-05-newsletter.de.md
@@ -160,7 +160,6 @@ Teile unsere Neuigkeiten in "Sozialen Netzwerken":
 
 * [Mastodon](https://fosstodon.org/@xmpp/) [EN]
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA) [EN]
-* [Twitter](https://twitter.com/xmpp) [EN]
 * [Reddit](https://www.reddit.com/r/xmpp/) [EN]
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/) [EN]
 

--- a/content/blog/newsletter/2022-03-05-newsletter.es.md
+++ b/content/blog/newsletter/2022-03-05-newsletter.es.md
@@ -158,7 +158,6 @@ Por favor, comparte la noticia a través de otras redes:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2022-03-05-newsletter.fr.md
+++ b/content/blog/newsletter/2022-03-05-newsletter.fr.md
@@ -158,7 +158,6 @@ Veuillez partager la nouvelle sur d’autres réseaux :
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2022-03-05-newsletter.md
+++ b/content/blog/newsletter/2022-03-05-newsletter.md
@@ -157,7 +157,6 @@ Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2022-04-05-newsletter.de.md
+++ b/content/blog/newsletter/2022-04-05-newsletter.de.md
@@ -154,7 +154,6 @@ Teile unsere Neuigkeiten in "Sozialen Netzwerken":
 
 * [Mastodon](https://fosstodon.org/@xmpp/) [EN]
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA) [EN]
-* [Twitter](https://twitter.com/xmpp) [EN]
 * [Reddit](https://www.reddit.com/r/xmpp/) [EN]
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/) [EN]
 

--- a/content/blog/newsletter/2022-04-05-newsletter.es.md
+++ b/content/blog/newsletter/2022-04-05-newsletter.es.md
@@ -160,7 +160,6 @@ Por favor, comparte la noticia a través de otras redes:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2022-04-05-newsletter.md
+++ b/content/blog/newsletter/2022-04-05-newsletter.md
@@ -157,7 +157,6 @@ Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2022-05-05-newsletter.de.md
+++ b/content/blog/newsletter/2022-05-05-newsletter.de.md
@@ -163,7 +163,6 @@ Ein Call for Experience (ein Aufruf für Erfahrungen) ist, wie ein Last Call, ei
 Teile unsere Neuigkeiten in "Sozialen Netzwerken":
 
 * [Mastodon](https://fosstodon.org/@xmpp/) [EN]
-* [Twitter](https://twitter.com/xmpp) [EN]
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA) [EN]
 * [Lemmy instanz](https://community.xmpp.net/) [EN]
 * [Reddit](https://www.reddit.com/r/xmpp/) [EN]

--- a/content/blog/newsletter/2022-05-05-newsletter.es.md
+++ b/content/blog/newsletter/2022-05-05-newsletter.es.md
@@ -165,7 +165,6 @@ Por favor, comparte la noticia a través de otras redes:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
-* [Twitter](https://twitter.com/xmpp)
 * [Reddit](https://www.reddit.com/r/xmpp/)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 

--- a/content/blog/newsletter/2022-05-05-newsletter.md
+++ b/content/blog/newsletter/2022-05-05-newsletter.md
@@ -162,7 +162,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-06-05-newsletter.de.md
+++ b/content/blog/newsletter/2022-06-05-newsletter.de.md
@@ -155,7 +155,6 @@ Ein Call for Experience (ein Aufruf für Erfahrungen) ist, wie ein Last Call, ei
 Teile unsere Neuigkeiten in "Sozialen Netzwerken":
 
 * [Mastodon](https://fosstodon.org/@xmpp/) [EN]
-* [Twitter](https://twitter.com/xmpp) [EN]
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA) [EN]
 * [Lemmy-Instanz](https://community.xmpp.net/) [EN]
 * [Reddit](https://www.reddit.com/r/xmpp/) [EN]

--- a/content/blog/newsletter/2022-06-05-newsletter.de.md
+++ b/content/blog/newsletter/2022-06-05-newsletter.de.md
@@ -27,7 +27,7 @@ Dies ist eine Gemeinschafstarbeit und wir wollen allen Übersetzer:innen für de
 - Der Google Summer of Code 2022 steht in den Startlöchern und das Programmieren beginnt bald! Begrüßt die beiden neuen Mitwirkenden Patiga und PawBud, die an Open-Source-Softwareprojekten in der XMPP-Umgebung arbeiten werden!
         - Patiga wird an [flexibleren Dateiübertragungen in Dino](https://summerofcode.withgoogle.com/programs/2022/projects/z9ixHTWZ) [EN] arbeiten. Mentoren werden fiaxh und Marvin W. sein - vielen Dank an euch beide!
         - PawBud wird daran arbeiten, [Unterstützung für A/V-Kommunikation über Jingle in ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19) [EN] hinzuzufügen. Mentoren werden JC Brand und vanitasvitae sein - vielen Dank auch an euch beide!
- Fühlt euch frei, die Nachricht über [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) [EN] oder [Twitter](https://mobile.twitter.com/xmpp/status/1529199174729728000) [EN] zu verbreiten. Weitere Einzelheiten findest du auf der dafür [vorgesehenen Seite unter xmpp.org](https://xmpp.org/community/gsoc-2022/) [EN].
+ Fühlt euch frei, die Nachricht über [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) [EN] zu verbreiten. Weitere Einzelheiten findest du auf der dafür [vorgesehenen Seite unter xmpp.org](https://xmpp.org/community/gsoc-2022/) [EN].
 - Die aktuelle [Abstimmungsphase für XSF-Mitglieder läuft noch](https://wiki.xmpp.org/web/Membership_Applications_Q2_2022) [EN]. Wenn du ein XSF-Mitglied bist, nutze bitte deine Chance, abzustimmen. Wenn du Interesse an einer Bewerbung hast, besuche unsere [entsprechende Seite](https://xmpp.org/community/membership/) [EN].
 
 ## XSF finanziell bewirtete Projekte

--- a/content/blog/newsletter/2022-06-05-newsletter.md
+++ b/content/blog/newsletter/2022-06-05-newsletter.md
@@ -26,7 +26,7 @@ This is a community effort, and we would like to thank translators for their con
   - **Patiga** will work on [more flexible file transfers in Dino](https://summerofcode.withgoogle.com/programs/2022/projects/z9ixHTWZ). Mentors will be **fiaxh** and **Marvin W.** - many thanks to both of you!
   - **PawBud** will work towards [adding support for A/V communication via Jingle in ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19). Mentors will be **JC Brand** and **vanitasvitae** - many thanks to both of you, too!
 
-  Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) or [Twitter](https://mobile.twitter.com/xmpp/status/1529199174729728000). More details in our [designated page at xmpp.org](https://xmpp.org/community/gsoc-2022/).
+  Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966). More details in our [designated page at xmpp.org](https://xmpp.org/community/gsoc-2022/).
 
 - The current XSF member [voting period is ongoing](https://wiki.xmpp.org/web/Membership_Applications_Q2_2022). If you are an XSF member, please take your chance to vote. If your are interest to apply visit our [related page](https://xmpp.org/community/membership/).
 

--- a/content/blog/newsletter/2022-06-05-newsletter.md
+++ b/content/blog/newsletter/2022-06-05-newsletter.md
@@ -158,7 +158,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-07-05-newsletter.de.md
+++ b/content/blog/newsletter/2022-07-05-newsletter.de.md
@@ -32,7 +32,7 @@ Der Google Summer of Code 2022 ist gestartet und das Programmieren hat schon beg
 - **PawBud** arbeitet daran, [Unterstützung für A/V-Kommunikation über Jingle in ConverseJS hinzuzufügen](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19) [EN]. Mentor:innen sind **JC Brand** und **vanitasvitae**.
     - [On-Boarding Erfahrung mit XSF (Converse)](https://xmpp.org/2022/06/on-boarding-experience-with-xsf-converse/) [EN]
 
-Fühle dich frei, diese News über [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) [EN] oder [Twitter](https://mobile.twitter.com/xmpp/status/1529199174729728000) zu verbreiten. Weitere Einzelheiten auf der dafür [vorgesehenen Seite unter xmpp.org](https://xmpp.org/community/gsoc-2022/) [EN].
+Fühle dich frei, diese News über [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) [EN] zu verbreiten. Weitere Einzelheiten auf der dafür [vorgesehenen Seite unter xmpp.org](https://xmpp.org/community/gsoc-2022/) [EN].
 
 ## XSF fiscal hosting Projekte
 

--- a/content/blog/newsletter/2022-07-05-newsletter.de.md
+++ b/content/blog/newsletter/2022-07-05-newsletter.de.md
@@ -141,7 +141,6 @@ Ein Call for Experience (ein Aufruf für Erfahrungen) ist, wie ein Last Call, ei
 Teile unsere Neuigkeiten in "Sozialen Netzwerken":
 
 * [Mastodon](https://fosstodon.org/@xmpp/) [EN]
-* [Twitter](https://twitter.com/xmpp) [EN]
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA) [EN]
 * [Lemmy-Instanz](https://community.xmpp.net/) [EN]
 * [Reddit](https://www.reddit.com/r/xmpp/) [EN]

--- a/content/blog/newsletter/2022-07-05-newsletter.md
+++ b/content/blog/newsletter/2022-07-05-newsletter.md
@@ -33,7 +33,7 @@ The Google Summer of Code 2022 has lifted off and coding started a while ago! Th
   - **PawBud** works towards [adding support for A/V communication via Jingle in ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19). Mentors are **JC Brand** and **vanitasvitae**.
     - [On-Boarding Experience with XSF (Converse)](https://xmpp.org/2022/06/on-boarding-experience-with-xsf-converse/)
 
-  Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) or [Twitter](https://mobile.twitter.com/xmpp/status/1529199174729728000). More details in our [designated page at xmpp.org](https://xmpp.org/community/gsoc-2022/).
+  Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966). More details in our [designated page at xmpp.org](https://xmpp.org/community/gsoc-2022/).
 
 ## XSF fiscal hosting projects
 

--- a/content/blog/newsletter/2022-07-05-newsletter.md
+++ b/content/blog/newsletter/2022-07-05-newsletter.md
@@ -141,7 +141,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-08-03-newsletter.de.md
+++ b/content/blog/newsletter/2022-08-03-newsletter.de.md
@@ -166,7 +166,6 @@ Ein Call for Experience (ein Aufruf für Erfahrungen) ist, wie ein Last Call, ei
 Teile doch bitte unsere Neuigkeiten auch in anderen Netzwerken:
 
 * [Mastodon](https://fosstodon.org/@xmpp/) [EN]
-* [Twitter](https://twitter.com/xmpp) [EN]
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA) [EN]
 * [Lemmy-Instanz](https://community.xmpp.net/) [EN]
 * [Reddit](https://www.reddit.com/r/xmpp/) [EN]

--- a/content/blog/newsletter/2022-08-03-newsletter.md
+++ b/content/blog/newsletter/2022-08-03-newsletter.md
@@ -165,7 +165,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-09-05-newsletter.de.md
+++ b/content/blog/newsletter/2022-09-05-newsletter.de.md
@@ -173,7 +173,6 @@ Ein Call for Experience (ein Aufruf für Erfahrungen) ist, wie ein Last Call, ei
 Teile doch bitte unsere Neuigkeiten auch in anderen Netzwerken:
 
 * [Mastodon](https://fosstodon.org/@xmpp/) [EN]
-* [Twitter](https://twitter.com/xmpp) [EN]
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA) [EN]
 * [Lemmy-Instanz](https://community.xmpp.net/) [EN]
 * [Reddit](https://www.reddit.com/r/xmpp/) [EN]

--- a/content/blog/newsletter/2022-09-05-newsletter.md
+++ b/content/blog/newsletter/2022-09-05-newsletter.md
@@ -168,7 +168,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-10-05-newsletter.fr.md
+++ b/content/blog/newsletter/2022-10-05-newsletter.fr.md
@@ -283,7 +283,6 @@ Partagez la nouvelle sur d’autres réseaux :
 
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-10-05-newsletter.md
+++ b/content/blog/newsletter/2022-10-05-newsletter.md
@@ -164,7 +164,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-11-05-newsletter.fr.md
+++ b/content/blog/newsletter/2022-11-05-newsletter.fr.md
@@ -265,7 +265,6 @@ Merci de partager la nouvelle sur d’autres réseaux :
 
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-11-05-newsletter.md
+++ b/content/blog/newsletter/2022-11-05-newsletter.md
@@ -155,7 +155,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-12-05-newsletter.fr.md
+++ b/content/blog/newsletter/2022-12-05-newsletter.fr.md
@@ -276,7 +276,6 @@ Merci de partager la nouvelle sur d’autres réseaux :
 
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2022-12-05-newsletter.md
+++ b/content/blog/newsletter/2022-12-05-newsletter.md
@@ -157,7 +157,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-02-05-newsletter.fr.md
+++ b/content/blog/newsletter/2023-02-05-newsletter.fr.md
@@ -227,7 +227,6 @@ Merci de partager la nouvelle sur d’autres réseaux :
 
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-02-05-newsletter.md
+++ b/content/blog/newsletter/2023-02-05-newsletter.md
@@ -180,7 +180,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-03-05-newsletter.fr.md
+++ b/content/blog/newsletter/2023-03-05-newsletter.fr.md
@@ -150,7 +150,6 @@ Merci de partager les nouvelles sur d’autres réseaux :
 
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-03-05-newsletter.md
+++ b/content/blog/newsletter/2023-03-05-newsletter.md
@@ -118,7 +118,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-04-05-newsletter.fr.md
+++ b/content/blog/newsletter/2023-04-05-newsletter.fr.md
@@ -151,7 +151,6 @@ Un _appel à l’expérience_ – comme un _dernier appel_ – est un appel expl
 Merci de partager les nouvelles sur d’autres réseaux :
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-04-05-newsletter.md
+++ b/content/blog/newsletter/2023-04-05-newsletter.md
@@ -153,7 +153,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-05-05-newsletter.fr.md
+++ b/content/blog/newsletter/2023-05-05-newsletter.fr.md
@@ -153,7 +153,6 @@ Merci de partager les nouvelles sur d’autres réseaux :
 
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-05-05-newsletter.md
+++ b/content/blog/newsletter/2023-05-05-newsletter.md
@@ -153,7 +153,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-06-05-newsletter.fr.md
+++ b/content/blog/newsletter/2023-06-05-newsletter.fr.md
@@ -194,7 +194,6 @@ Merci de partager les nouvelles sur d’autres réseaux :
 
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-06-05-newsletter.md
+++ b/content/blog/newsletter/2023-06-05-newsletter.md
@@ -135,7 +135,6 @@ A Call For Experience - like a Last Call, is an explicit call for comments, but 
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-07-07-newsletter.fr.md
+++ b/content/blog/newsletter/2023-07-07-newsletter.fr.md
@@ -142,7 +142,6 @@ Merci de partager les nouvelles sur d’autres réseaux :
 
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-07-07-newsletter.md
+++ b/content/blog/newsletter/2023-07-07-newsletter.md
@@ -133,7 +133,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [Lemmy instance](https://community.xmpp.net/)
 * [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-09-05-newsletter.fr.md
+++ b/content/blog/newsletter/2023-09-05-newsletter.fr.md
@@ -129,7 +129,6 @@ Les derniers appels sont lancés une fois que tout le monde semble satisfait de 
 Merci de partager les nouvelles sur d’autres réseaux :
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [Lemmy instance](https://community.xmpp.net/)
 - [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-09-05-newsletter.md
+++ b/content/blog/newsletter/2023-09-05-newsletter.md
@@ -129,7 +129,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [Lemmy instance](https://community.xmpp.net/)
 - [Reddit](https://www.reddit.com/r/xmpp/)

--- a/content/blog/newsletter/2023-10-05-newsletter.fr.md
+++ b/content/blog/newsletter/2023-10-05-newsletter.fr.md
@@ -220,7 +220,6 @@ N'hésitez pas à partager les nouvelles sur d'autres réseaux :
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
 
-- [Twitter](https://twitter.com/xmpp)
 
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 

--- a/content/blog/newsletter/2023-10-05-newsletter.md
+++ b/content/blog/newsletter/2023-10-05-newsletter.md
@@ -118,7 +118,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2023-11-05-newsletter.fr.md
+++ b/content/blog/newsletter/2023-11-05-newsletter.fr.md
@@ -166,7 +166,6 @@ Les _derniers appels_ sont lancés une fois que tout le monde semble satisfait d
 N’hésitez pas à partager les nouvelles sur d’autres réseaux :
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2023-11-05-newsletter.md
+++ b/content/blog/newsletter/2023-11-05-newsletter.md
@@ -152,7 +152,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2023-12-05-newsletter.fr.md
+++ b/content/blog/newsletter/2023-12-05-newsletter.fr.md
@@ -170,7 +170,6 @@ Les _derniers appels_ sont lancés une fois que tout le monde semble satisfait d
 N’hésitez pas à partager les nouvelles sur d’autres réseaux :
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2023-12-05-newsletter.md
+++ b/content/blog/newsletter/2023-12-05-newsletter.md
@@ -122,7 +122,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-02-05-newsletter.fr.md
+++ b/content/blog/newsletter/2024-02-05-newsletter.fr.md
@@ -151,7 +151,6 @@ Les derniers appels sont lancés une fois que tout le monde semble satisfait de 
 N’hésitez pas à partager la nouvelle sur d’autres réseaux :
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Instance Lemmy (non officielle)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-02-05-newsletter.md
+++ b/content/blog/newsletter/2024-02-05-newsletter.md
@@ -151,7 +151,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-03-10-newsletter.md
+++ b/content/blog/newsletter/2024-03-10-newsletter.md
@@ -114,7 +114,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-04-05-newsletter.it.md
+++ b/content/blog/newsletter/2024-04-05-newsletter.it.md
@@ -178,7 +178,6 @@ Last Call sono emesse una volta che tutti sembrano soddisfatti dello stato attua
 Condividete la notizia sui "social network":
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Istanza di Lemmy (non ufficiale)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-04-05-newsletter.md
+++ b/content/blog/newsletter/2024-04-05-newsletter.md
@@ -194,7 +194,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-05-05-newsletter.it.md
+++ b/content/blog/newsletter/2024-05-05-newsletter.it.md
@@ -126,7 +126,6 @@ Last Call sono emesse una volta che tutti sembrano soddisfatti dello stato attua
 Condividete la notizia sui "social network":
 
 * [Mastodon](https://fosstodon.org/@xmpp/)
-* [Twitter](https://twitter.com/xmpp)
 * [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 * [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 * [Istanza di Lemmy (non ufficiale)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-05-05-newsletter.md
+++ b/content/blog/newsletter/2024-05-05-newsletter.md
@@ -128,7 +128,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-06-05-newsletter.es.md
+++ b/content/blog/newsletter/2024-06-05-newsletter.es.md
@@ -124,7 +124,6 @@ Los "Últimos Llamados" ("Last calls") se emiten una vez que todos parecen estar
 Por favor difunda las noticias en otras redes:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-06-05-newsletter.it.md
+++ b/content/blog/newsletter/2024-06-05-newsletter.it.md
@@ -148,7 +148,6 @@ Last Call sono emesse una volta che tutti sembrano soddisfatti dello stato attua
 Condividete la notizia sui "social network":
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Istanza di Lemmy (non ufficiale)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-06-05-newsletter.md
+++ b/content/blog/newsletter/2024-06-05-newsletter.md
@@ -121,7 +121,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-07-05-newsletter.es.md
+++ b/content/blog/newsletter/2024-07-05-newsletter.es.md
@@ -131,7 +131,6 @@ Los "Últimos Llamados" ("Last calls") se emiten una vez que todos parecen estar
 Por favor difunda las noticias en otras redes:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-07-05-newsletter.it.md
+++ b/content/blog/newsletter/2024-07-05-newsletter.it.md
@@ -176,7 +176,6 @@ Last Call sono emesse una volta che tutti sembrano soddisfatti dello stato attua
 Condividete la notizia sui "social network":
 
 -   [Mastodon](https://fosstodon.org/@xmpp/)
--   [Twitter](https://twitter.com/xmpp)
 -   [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 -   [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 -   [Istanza di Lemmy (non ufficiale)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-07-05-newsletter.md
+++ b/content/blog/newsletter/2024-07-05-newsletter.md
@@ -131,7 +131,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-08-05-newsletter.de.md
+++ b/content/blog/newsletter/2024-08-05-newsletter.de.md
@@ -140,7 +140,6 @@ Letzte Aufrufe (_Last Calls_) erfolgen sobald sich der Status eines XEPs konsoli
 Teile diese Neuigkeiten auch in anderen Netzwerken:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (inoffiziell)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-08-05-newsletter.es.md
+++ b/content/blog/newsletter/2024-08-05-newsletter.es.md
@@ -142,7 +142,6 @@ Los "Últimos Llamados" ("Last calls") se emiten una vez que todos parecen estar
 Por favor difunda las noticias en otras redes:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-08-05-newsletter.it.md
+++ b/content/blog/newsletter/2024-08-05-newsletter.it.md
@@ -141,7 +141,6 @@ Last Call sono emesse una volta che tutti sembrano soddisfatti dello stato attua
 Condividete la notizia sui "social network":
 
 -   [Mastodon](https://fosstodon.org/@xmpp/)
--   [Twitter](https://twitter.com/xmpp)
 -   [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 -   [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 -   [Istanza di Lemmy (non ufficiale)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-08-05-newsletter.md
+++ b/content/blog/newsletter/2024-08-05-newsletter.md
@@ -139,7 +139,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-09-05-newsletter.de.md
+++ b/content/blog/newsletter/2024-09-05-newsletter.de.md
@@ -146,7 +146,6 @@ Letzte Aufrufe (_Last Calls_) erfolgen sobald sich der Status eines XEPs konsoli
 Teile diese Neuigkeiten auch in anderen Netzwerken:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (inoffiziell)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-09-05-newsletter.es.md
+++ b/content/blog/newsletter/2024-09-05-newsletter.es.md
@@ -145,7 +145,6 @@ Los "Últimos Llamados" ("Last calls") se emiten una vez que todos parecen estar
 Por favor difunda las noticias en otras redes:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-09-05-newsletter.fr.md
+++ b/content/blog/newsletter/2024-09-05-newsletter.fr.md
@@ -130,7 +130,6 @@ Aucune XEP déclarée dépréciée ce mois-ci.
 N’hésitez pas à partager les nouvelles sur d’autres réseaux :
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Instance Lemmy (non officiel)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-09-05-newsletter.it.md
+++ b/content/blog/newsletter/2024-09-05-newsletter.it.md
@@ -179,7 +179,6 @@ Last Call sono emesse una volta che tutti sembrano soddisfatti dello stato attua
 Condividete la notizia sui "social network":
 
 -   [Mastodon](https://fosstodon.org/@xmpp/)
--   [Twitter](https://twitter.com/xmpp)
 -   [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 -   [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 -   [Istanza di Lemmy (non ufficiale)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-09-05-newsletter.md
+++ b/content/blog/newsletter/2024-09-05-newsletter.md
@@ -145,7 +145,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-10-05-newsletter.de.md
+++ b/content/blog/newsletter/2024-10-05-newsletter.de.md
@@ -151,7 +151,6 @@ Letzte Aufrufe (_Last Calls_) erfolgen sobald sich der Status eines XEPs konsoli
 Teile diese Neuigkeiten auch in anderen Netzwerken:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (inoffiziell)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-10-05-newsletter.it.md
+++ b/content/blog/newsletter/2024-10-05-newsletter.it.md
@@ -169,7 +169,6 @@ Last Call sono emesse una volta che tutti sembrano soddisfatti dello stato attua
 Condividete la notizia sui "social network":
 
 -   [Mastodon](https://fosstodon.org/@xmpp/)
--   [Twitter](https://twitter.com/xmpp)
 -   [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 -   [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 -   [Istanza di Lemmy (non ufficiale)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-10-05-newsletter.md
+++ b/content/blog/newsletter/2024-10-05-newsletter.md
@@ -148,7 +148,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-11-05-newsletter.de.md
+++ b/content/blog/newsletter/2024-11-05-newsletter.de.md
@@ -137,7 +137,6 @@ Letzte Aufrufe (_Last Calls_) erfolgen sobald sich der Status eines XEPs konsoli
 Teile diese Neuigkeiten auch in anderen Netzwerken:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (inoffiziell)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-11-05-newsletter.md
+++ b/content/blog/newsletter/2024-11-05-newsletter.md
@@ -132,7 +132,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-11-07-newsletter.it.md
+++ b/content/blog/newsletter/2024-11-07-newsletter.it.md
@@ -181,7 +181,6 @@ Last Call sono emesse una volta che tutti sembrano soddisfatti dello stato attua
 Condividete la notizia sui "social network":
 
 -   [Mastodon](https://fosstodon.org/@xmpp/)
--   [Twitter](https://twitter.com/xmpp)
 -   [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 -   [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 -   [Istanza di Lemmy (non ufficiale)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-12-05-newsletter.md
+++ b/content/blog/newsletter/2024-12-05-newsletter.md
@@ -126,7 +126,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2024-12-05_newsletter.de.md
+++ b/content/blog/newsletter/2024-12-05_newsletter.de.md
@@ -132,7 +132,6 @@ Letzte Aufrufe (_Last Calls_) erfolgen sobald sich der Status eines XEPs konsoli
 Teile diese Neuigkeiten auch in anderen Netzwerken:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (inoffiziell)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2025-01-05-newsletter.de.md
+++ b/content/blog/newsletter/2025-01-05-newsletter.de.md
@@ -139,7 +139,6 @@ Letzte Aufrufe (_Last Calls_) erfolgen sobald sich der Status eines XEPs konsoli
 Teile diese Neuigkeiten auch in anderen Netzwerken:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (inoffiziell)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2025-01-05-newsletter.it.md
+++ b/content/blog/newsletter/2025-01-05-newsletter.it.md
@@ -172,7 +172,6 @@ Last Call sono emesse una volta che tutti sembrano soddisfatti dello stato attua
 Condividete la notizia sui "social network":
 
 -   [Mastodon](https://fosstodon.org/@xmpp/)
--   [Twitter](https://twitter.com/xmpp)
 -   [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 -   [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 -   [Istanza di Lemmy (non ufficiale)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2025-01-05-newsletter.md
+++ b/content/blog/newsletter/2025-01-05-newsletter.md
@@ -134,7 +134,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2025-02-05-newsletter.de.md
+++ b/content/blog/newsletter/2025-02-05-newsletter.de.md
@@ -146,7 +146,6 @@ Letzte Aufrufe (_Last Calls_) erfolgen sobald sich der Status eines XEPs konsoli
 Teile diese Neuigkeiten auch in anderen Netzwerken:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (inoffiziell)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2025-02-05-newsletter.md
+++ b/content/blog/newsletter/2025-02-05-newsletter.md
@@ -146,7 +146,6 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Twitter](https://twitter.com/xmpp)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [Lemmy instance (unofficial)](https://slrpnk.net/c/xmpp)

--- a/content/community/gsoc-2022.de.md
+++ b/content/community/gsoc-2022.de.md
@@ -35,7 +35,6 @@ Wenn du teilnehmen möchtest, empfehlen wir dir die folgenden Vorbereitungen:
 
 Schauen dir auch unsere Medienkanäle an!
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 

--- a/content/community/gsoc-2022.en.md
+++ b/content/community/gsoc-2022.en.md
@@ -34,7 +34,7 @@ Our contributors are Patiga and PawBud - warm welcome and its great that you cho
 - Patiga will work on more [flexible file transfers in Dino](https://summerofcode.withgoogle.com/programs/2022/projects/z9ixHTWZ)
 - PawBud will work towards adding support for [A/V communication via Jingle in ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19)
 
-Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) or [Twitter](https://twitter.com/xmpp/status/1529199174729728000).
+Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/108358826402429966).
 
 ### Resources
 

--- a/content/community/gsoc-2022.en.md
+++ b/content/community/gsoc-2022.en.md
@@ -44,7 +44,6 @@ Feel free to spread the word via [Mastodon](https://fosstodon.org/@xmpp/10835882
 
 Checkout our media channels!
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 

--- a/content/community/gsoc-2022.es.md
+++ b/content/community/gsoc-2022.es.md
@@ -46,7 +46,6 @@ No dudes en correr la voz a través de [Mastodon](https://fosstodon.org/@xmpp/10
 
 Consulta nuestros canales de comunicación.
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 

--- a/content/community/gsoc-2022.es.md
+++ b/content/community/gsoc-2022.es.md
@@ -36,7 +36,7 @@ Nuestros colaboradores son **Patiga** y **PawBud** - ¡bienvenidos y es genial q
 - **Patiga** trabajará en más [transferencias de archivos flexibles en Dino](https://summerofcode.withgoogle.com/programs/2022/projects/z9ixHTWZ)
 - **PawBud** trabajará para añadir soporte para [comunicación A/V vía Jingle en ConverseJS](https://summerofcode.withgoogle.com/programs/2022/projects/0nRwZN19)
 
-No dudes en correr la voz a través de [Mastodon](https://fosstodon.org/@xmpp/108358826402429966) o [Twitter](https://twitter.com/xmpp/status/1529199174729728000).
+No dudes en correr la voz a través de [Mastodon](https://fosstodon.org/@xmpp/108358826402429966).
 
 ### Recursos
 

--- a/content/community/gsoc-2022.fr.md
+++ b/content/community/gsoc-2022.fr.md
@@ -35,7 +35,6 @@ Si vous souhaitez participer, nous vous recommandons les préparatifs suivants :
 
 Consultez nos canaux médiatiques !
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 

--- a/content/community/gsoc-2023.de.md
+++ b/content/community/gsoc-2023.de.md
@@ -39,7 +39,6 @@ Wenn du interessiert bist Code beizutragen oder ein Projekt mit Interesse an ein
 
 Schaue dir auch unsere Medienkanäle an!
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 

--- a/content/community/gsoc-2023.en.md
+++ b/content/community/gsoc-2023.en.md
@@ -36,7 +36,6 @@ If you are an interested contributor or project - the first two links are key to
 
 Checkout our media channels!
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 

--- a/content/community/gsoc-2023.fr.md
+++ b/content/community/gsoc-2023.fr.md
@@ -38,7 +38,6 @@ Si vous êtes une contributrice intéressée, un contributeur intéressé ou un 
 
 Consultez nos canaux média !
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 

--- a/content/community/gsoc-2023.it.md
+++ b/content/community/gsoc-2023.it.md
@@ -39,7 +39,6 @@ Se sei un collaboratore o un progetto interessato, assicurati di leggere i primi
 
 Date un'occhiata anche ai nostri canali multimediali!
 
-- [Twitter](https://twitter.com/xmpp)
 - [Mastodon/Fediverse](https://fosstodon.org/@xmpp/)
 - [Youtube](https://www.youtube.com/c/XMPPStandardsFoundation)
 


### PR DESCRIPTION
edit: this is now 1 more commit on top of https://github.com/xsf/xmpp.org/pull/1489