### PR TITLE
Rename mierenhoop/xmpp DOAP to picomemo

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -1162,15 +1162,6 @@
     },
     {
         "categories": [
-            "library"
-        ],
-        "doap": "https://raw.githubusercontent.com/mierenhoop/picomemo/refs/heads/master/project.doap",
-        "name": "picomemo",
-        "platforms": [],
-        "url": null
-    },
-    {
-        "categories": [
             "client"
         ],
         "doap": "https://raw.githubusercontent.com/miranda-ng/miranda-ng/master/docs/miranda.doap",
@@ -1316,6 +1307,15 @@
             "Windows"
         ],
         "url": "https://www.oracle.com/index.html"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": "https://raw.githubusercontent.com/mierenhoop/picomemo/refs/heads/master/project.doap",
+        "name": "picomemo",
+        "platforms": [],
+        "url": null
     },
     {
         "categories": [

--- a/data/software.json
+++ b/data/software.json
@@ -1164,8 +1164,8 @@
         "categories": [
             "library"
         ],
-        "doap": "https://raw.githubusercontent.com/mierenhoop/xmpp/refs/heads/doap-file/project.doap",
-        "name": "mierenhoop/xmpp",
+        "doap": "https://raw.githubusercontent.com/mierenhoop/picomemo/refs/heads/master/project.doap",
+        "name": "picomemo",
         "platforms": [],
         "url": null
     },


### PR DESCRIPTION
Hi, the project now only provides an OMEMO implementation and has re-branded accordingly.