### PR TITLE
Update Software Archive

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -97,18 +97,6 @@
     },
     {
         "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "as3xmpp",
-        "platforms": [
-            "ActionScript",
-            "Flash"
-        ],
-        "url": "https://github.com/lyokato/as3xmppclient"
-    },
-    {
-        "categories": [
             "client"
         ],
         "doap": "https://astrachat.com/astrachat-clients.xml",
@@ -466,17 +454,6 @@
             "library"
         ],
         "doap": null,
-        "name": "Echomine Feridian",
-        "platforms": [
-            "Java"
-        ],
-        "url": "https://github.com/jdevelop/feridian"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
         "name": "Eiffel",
         "platforms": [
             "Eiffel"
@@ -503,17 +480,6 @@
             "Windows"
         ],
         "url": "https://www.emclient.com"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "emite",
-        "platforms": [
-            "Java"
-        ],
-        "url": "https://github.com/EmiteGWT/emite"
     },
     {
         "categories": [
@@ -647,28 +613,6 @@
             "library"
         ],
         "doap": null,
-        "name": "headstock",
-        "platforms": [
-            "Python"
-        ],
-        "url": "https://github.com/Lawouach/headstock"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "hsxmpp",
-        "platforms": [
-            "Haskell"
-        ],
-        "url": "http://\u05d7\u05e0\u05d5\u05da.se"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
         "name": "hxmpp",
         "platforms": [
             "Haxe"
@@ -686,28 +630,6 @@
             "Windows"
         ],
         "url": "https://www.icewarp.com"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "iksemel",
-        "platforms": [
-            "C"
-        ],
-        "url": "https://github.com/meduketto/iksemel"
-    },
-    {
-        "categories": [
-            "server"
-        ],
-        "doap": null,
-        "name": "in.jabberd",
-        "platforms": [
-            "Linux"
-        ],
-        "url": "https://github.com/bobintetley/inetdxtra/tree/master/in.jabberd"
     },
     {
         "categories": [
@@ -942,17 +864,6 @@
             "library"
         ],
         "doap": null,
-        "name": "jQuery-XMPP-plugin",
-        "platforms": [
-            "JavaScript"
-        ],
-        "url": "https://github.com/maxpowel/jQuery-XMPP-plugin"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
         "name": "Jreen",
         "platforms": [
             "C++",
@@ -1069,17 +980,6 @@
         "name": "libstrophe",
         "platforms": [],
         "url": null
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "Lightr",
-        "platforms": [
-            "PHP"
-        ],
-        "url": "https://github.com/myYearbook/lightr"
     },
     {
         "categories": [
@@ -1492,18 +1392,6 @@
             "library"
         ],
         "doap": null,
-        "name": "seesmic-as3-xmpp",
-        "platforms": [
-            "ActionScript",
-            "Flash"
-        ],
-        "url": "https://code.google.com/archive/p/seesmic-as3-xmpp"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
         "name": "Sharp.Xmpp",
         "platforms": [
             ".net",
@@ -1534,19 +1422,6 @@
             "Linux"
         ],
         "url": "http://siemens-enterprise.com"
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": null,
-        "name": "Sim-IM",
-        "platforms": [
-            "FreeBSD",
-            "Linux",
-            "Windows"
-        ],
-        "url": "http://www.sim-im.org/index.php?title=Main_Page"
     },
     {
         "categories": [
@@ -2047,32 +1922,10 @@
         "categories": [
             "library"
         ],
-        "doap": null,
-        "name": "xmpp-psn",
-        "platforms": [
-            "Python"
-        ],
-        "url": "https://code.google.com/archive/p/xmpp-psn"
-    },
-    {
-        "categories": [
-            "library"
-        ],
         "doap": "/hosted-doap/xmpp-js.doap",
         "name": "xmpp.js",
         "platforms": [],
         "url": null
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "xmpp4js",
-        "platforms": [
-            "JavaScript"
-        ],
-        "url": "https://xmpp4js.sourceforge.net"
     },
     {
         "categories": [
@@ -2084,17 +1937,6 @@
             "Ruby"
         ],
         "url": "https://xmpp4r.github.io/"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "xmpp4r-simple",
-        "platforms": [
-            "Ruby"
-        ],
-        "url": "https://github.com/blaine/xmpp4r-simple"
     },
     {
         "categories": [
@@ -2117,17 +1959,6 @@
             "Linux"
         ],
         "url": "https://github.com/stanson-ch/xmppcd"
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": null,
-        "name": "xmppchat",
-        "platforms": [
-            "Browser"
-        ],
-        "url": "https://babelmonkeys.de"
     },
     {
         "categories": [
@@ -2170,17 +2001,6 @@
             "Python"
         ],
         "url": "https://xmpppy.sourceforge.net"
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": null,
-        "name": "XMPPWebChat",
-        "platforms": [
-            "Browser"
-        ],
-        "url": "https://github.com/udayg/xmppwebchat"
     },
     {
         "categories": [

--- a/data/software.json
+++ b/data/software.json
@@ -193,17 +193,6 @@
             "client"
         ],
         "doap": null,
-        "name": "Beem",
-        "platforms": [
-            "Android"
-        ],
-        "url": "https://elyzion.net/projects/beem"
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": null,
         "name": "BitlBee",
         "platforms": [
             "BSD",
@@ -278,17 +267,6 @@
             "Linux"
         ],
         "url": "http://buddycloud.com"
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": null,
-        "name": "Candy",
-        "platforms": [
-            "Browser"
-        ],
-        "url": "https://candy-chat.github.io/candy/"
     },
     {
         "categories": [
@@ -711,17 +689,6 @@
     },
     {
         "categories": [
-            "server"
-        ],
-        "doap": null,
-        "name": "iChat Server",
-        "platforms": [
-            "macOS"
-        ],
-        "url": "https://www.apple.com"
-    },
-    {
-        "categories": [
             "library"
         ],
         "doap": null,
@@ -812,19 +779,6 @@
     },
     {
         "categories": [
-            "server"
-        ],
-        "doap": null,
-        "name": "Jabber XCP",
-        "platforms": [
-            "Linux",
-            "Solaris",
-            "Windows"
-        ],
-        "url": "https://www.cisco.com"
-    },
-    {
-        "categories": [
             "client"
         ],
         "doap": "https://codeberg.org/emacs-jabber/emacs-jabber/raw/branch/production/doap.xml",
@@ -844,17 +798,6 @@
             "Mono"
         ],
         "url": "https://code.google.com/archive/p/jabber-net/"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "jabber.py",
-        "platforms": [
-            "Python"
-        ],
-        "url": "https://jabberpy.sourceforge.net"
     },
     {
         "categories": [
@@ -1058,17 +1001,6 @@
         "name": "Kaidan",
         "platforms": [],
         "url": null
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": null,
-        "name": "Kaiwa",
-        "platforms": [
-            "Browser"
-        ],
-        "url": "https://github.com/getkaiwa/kaiwa"
     },
     {
         "categories": [
@@ -1662,17 +1594,6 @@
     },
     {
         "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "SleekXMPP",
-        "platforms": [
-            "Python"
-        ],
-        "url": "https://github.com/fritzy/SleekXMPP"
-    },
-    {
-        "categories": [
             "component"
         ],
         "doap": "https://codeberg.org/slidge/slidge/raw/branch/main/doap.xml",
@@ -1880,17 +1801,6 @@
             "Linux"
         ],
         "url": "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg-doc.git;a=blob;f=tools/txxmpp.c"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "txmpp",
-        "platforms": [
-            "C++"
-        ],
-        "url": "https://github.com/rpavlik/txmpp"
     },
     {
         "categories": [

--- a/data/software.json
+++ b/data/software.json
@@ -710,19 +710,6 @@
     },
     {
         "categories": [
-            "library"
-        ],
-        "doap": null,
-        "name": "jabber.net",
-        "platforms": [
-            ".net",
-            "C#",
-            "Mono"
-        ],
-        "url": "https://code.google.com/archive/p/jabber-net/"
-    },
-    {
-        "categories": [
             "client"
         ],
         "doap": null,

--- a/data/software_archive.json
+++ b/data/software_archive.json
@@ -191,6 +191,19 @@
             "library"
         ],
         "doap": null,
+        "name": "Jabber-Net",
+        "platforms": [
+            ".net",
+            "C#",
+            "Mono"
+        ],
+        "url": "https://github.com/xmppo/Jabber-Net"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
         "name": "jabber.py",
         "platforms": [
             "Python"

--- a/data/software_archive.json
+++ b/data/software_archive.json
@@ -3,10 +3,32 @@
         "categories": [
             "client"
         ],
+        "doap": null,
+        "name": "Beem",
+        "platforms": [
+            "Android"
+        ],
+        "url": "https://elyzion.net/projects/beem"
+    },
+    {
+        "categories": [
+            "client"
+        ],
         "doap": "https://codeberg.org/kriztan/blabber.im/raw/branch/master/blabber.im.doap",
         "name": "blabber.im",
         "platforms": [],
         "url": null
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "Candy",
+        "platforms": [
+            "Browser"
+        ],
+        "url": "https://candy-chat.github.io/candy/"
     },
     {
         "categories": [
@@ -29,6 +51,17 @@
             "Windows"
         ],
         "url": "http://coversant.com"
+    },
+    {
+        "categories": [
+            "server"
+        ],
+        "doap": null,
+        "name": "iChat Server",
+        "platforms": [
+            "macOS"
+        ],
+        "url": "https://www.apple.com"
     },
     {
         "categories": [
@@ -61,6 +94,30 @@
             "Java"
         ],
         "url": "https://java.net/projects/jso"
+    },
+    {
+        "categories": [
+            "server"
+        ],
+        "doap": null,
+        "name": "Jabber XCP",
+        "platforms": [
+            "Linux",
+            "Solaris",
+            "Windows"
+        ],
+        "url": "https://www.cisco.com/c/en/us/products/unified-communications/jabber-extensible-communications-platform-xcp/index.html"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "jabber.py",
+        "platforms": [
+            "Python"
+        ],
+        "url": "https://jabberpy.sourceforge.net"
     },
     {
         "categories": [
@@ -97,6 +154,17 @@
             "Browser"
         ],
         "url": "https://github.com/sstrigler/jwchat"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "Kaiwa",
+        "platforms": [
+            "Browser"
+        ],
+        "url": "https://github.com/getkaiwa/kaiwa"
     },
     {
         "categories": [
@@ -144,6 +212,17 @@
     },
     {
         "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "SleekXMPP",
+        "platforms": [
+            "Python"
+        ],
+        "url": "https://github.com/fritzy/SleekXMPP"
+    },
+    {
+        "categories": [
             "client"
         ],
         "doap": null,
@@ -174,6 +253,17 @@
             "Mobile"
         ],
         "url": "http://talkonaut.com"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "txmpp",
+        "platforms": [
+            "C++"
+        ],
+        "url": "https://github.com/rpavlik/txmpp"
     },
     {
         "categories": [

--- a/data/software_archive.json
+++ b/data/software_archive.json
@@ -1,6 +1,18 @@
 [
     {
         "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "as3xmppclient",
+        "platforms": [
+            "ActionScript",
+            "Flash"
+        ],
+        "url": "https://github.com/lyokato/as3xmppclient"
+    },
+    {
+        "categories": [
             "client"
         ],
         "doap": null,
@@ -54,6 +66,50 @@
     },
     {
         "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "Echomine Feridian",
+        "platforms": [
+            "Java"
+        ],
+        "url": "https://github.com/jdevelop/feridian"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "emite",
+        "platforms": [
+            "Java"
+        ],
+        "url": "https://github.com/EmiteGWT/emite"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "headstock",
+        "platforms": [
+            "Python"
+        ],
+        "url": "https://github.com/Lawouach/headstock"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "hsxmpp",
+        "platforms": [
+            "Haskell"
+        ],
+        "url": "http://\u05d7\u05e0\u05d5\u05da.se/hsxmpp"
+    },
+    {
+        "categories": [
             "server"
         ],
         "doap": null,
@@ -62,6 +118,17 @@
             "macOS"
         ],
         "url": "https://www.apple.com"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "iksemel",
+        "platforms": [
+            "C"
+        ],
+        "url": "https://github.com/meduketto/iksemel"
     },
     {
         "categories": [
@@ -83,6 +150,17 @@
             "macOS"
         ],
         "url": "https://www.shape.ag/en/"
+    },
+    {
+        "categories": [
+            "server"
+        ],
+        "doap": null,
+        "name": "in.jabberd",
+        "platforms": [
+            "Linux"
+        ],
+        "url": "https://github.com/bobintetley/inetdxtra/tree/master/in.jabberd"
     },
     {
         "categories": [
@@ -146,6 +224,17 @@
     },
     {
         "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "jQuery-XMPP-plugin",
+        "platforms": [
+            "JavaScript"
+        ],
+        "url": "https://github.com/maxpowel/jQuery-XMPP-plugin"
+    },
+    {
+        "categories": [
             "client"
         ],
         "doap": null,
@@ -182,6 +271,17 @@
             "library"
         ],
         "doap": null,
+        "name": "Lightr",
+        "platforms": [
+            "PHP"
+        ],
+        "url": "https://github.com/myYearbook/lightr"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
         "name": "oajabber",
         "platforms": [
             "C++"
@@ -209,6 +309,31 @@
             "Windows"
         ],
         "url": "http://forum.qip.ru"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "seesmic-as3-xmpp",
+        "platforms": [
+            "ActionScript",
+            "Flash"
+        ],
+        "url": "https://code.google.com/archive/p/seesmic-as3-xmpp"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "Sim-IM",
+        "platforms": [
+            "FreeBSD",
+            "Linux",
+            "Windows"
+        ],
+        "url": "http://www.sim-im.org"
     },
     {
         "categories": [
@@ -276,5 +401,60 @@
             "Flash"
         ],
         "url": "http://www.igniterealtime.org/projects/xiff/"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "xmpp-psn",
+        "platforms": [
+            "Python"
+        ],
+        "url": "https://code.google.com/archive/p/xmpp-psn"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "xmpp4js",
+        "platforms": [
+            "JavaScript"
+        ],
+        "url": "https://xmpp4js.sourceforge.net"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "xmpp4r-simple",
+        "platforms": [
+            "Ruby"
+        ],
+        "url": "https://github.com/blaine/xmpp4r-simple"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "xmppchat",
+        "platforms": [
+            "Browser"
+        ],
+        "url": "https://cgit.babelmonkeys.de/?p=xmppchat.git;a=summary"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "XMPPWebChat",
+        "platforms": [
+            "Browser"
+        ],
+        "url": "https://github.com/udayg/xmppwebchat"
     }
 ]

--- a/data/software_archive.json
+++ b/data/software_archive.json
@@ -3,6 +3,15 @@
         "categories": [
             "client"
         ],
+        "doap": "https://codeberg.org/kriztan/blabber.im/raw/branch/master/blabber.im.doap",
+        "name": "blabber.im",
+        "platforms": [],
+        "url": null
+    },
+    {
+        "categories": [
+            "client"
+        ],
         "doap": null,
         "name": "Coversant SoapBox Communicator",
         "platforms": [
@@ -177,14 +186,5 @@
             "Flash"
         ],
         "url": "http://www.igniterealtime.org/projects/xiff/"
-    },
-    {
-        "categories": [
-            "client"
-        ],
-        "doap": "https://codeberg.org/kriztan/blabber.im/raw/branch/master/blabber.im.doap",
-        "name": "blabber.im",
-        "platforms": [],
-        "url": null
     }
 ]


### PR DESCRIPTION
- Fix alphabetical order in the `software_archive.json`.
- Move discontinued projects to the Software Archive: Beem, Candy, iChat Server, Jabber XCP, jabber.py, Kaiwa, SleekXMPP, txmpp.
- Move dead projects to the Software Archive: as3xmpp (renamed to as3xmppclient), Echomine Feridian, emite, headstock, hsxmpp, iksemel, in.jabberd, jQuery-XMPP-plugin, Lightr, seesmic-as3-xmpp, Sim-IM, xmpp-psn, xmpp4js, xmpp4r-simple, xmppchat, XMPPWebChat.
- Replace jabber-net with [Jabber-Net](https://github.com/xmppo/Jabber-Net), "a modern fork". Since Jabber-Net is deprecated, move it to the Software Archive.

Some links are fixed.