### PR TITLE
Polish software lists

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -1299,17 +1299,6 @@
             "library"
         ],
         "doap": null,
-        "name": "pyxmpp",
-        "platforms": [
-            "Python"
-        ],
-        "url": "https://github.com/Jajcus/pyxmpp"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": null,
         "name": "pyxmpp2",
         "platforms": [
             "Python"

--- a/data/software.json
+++ b/data/software.json
@@ -1579,6 +1579,19 @@
     },
     {
         "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "Swift",
+        "platforms": [
+            "Linux",
+            "macOS",
+            "Windows"
+        ],
+        "url": "https://swift.im/swift.html"
+    },
+    {
+        "categories": [
             "library"
         ],
         "doap": "/hosted-doap/swiften.doap",
@@ -1979,6 +1992,20 @@
             "Python"
         ],
         "url": "https://xmpppy.sourceforge.net"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "YateClient",
+        "platforms": [
+            "FreeBSD",
+            "Linux",
+            "macOS",
+            "Windows"
+        ],
+        "url": "https://www.yate.ro/opensource.php?page=yateclient"
     },
     {
         "categories": [

--- a/data/software.json
+++ b/data/software.json
@@ -754,7 +754,7 @@
         "platforms": [
             "Tcl"
         ],
-        "url": "http://coccinella.im"
+        "url": "https://coccinella.im/node/36.html"
     },
     {
         "categories": [
@@ -801,7 +801,7 @@
         "platforms": [
             "Browser"
         ],
-        "url": "https://jappix.org"
+        "url": "https://github.com/jappix/Jappix"
     },
     {
         "categories": [
@@ -1175,7 +1175,7 @@
             "Solaris",
             "Windows"
         ],
-        "url": "https://www.oracle.com"
+        "url": "https://docs.oracle.com/en/industries/communications/instant-messaging-server/index.html"
     },
     {
         "categories": [
@@ -1709,7 +1709,7 @@
         "platforms": [
             "BlackBerry"
         ],
-        "url": "https://www.vayusphere.com"
+        "url": "https://www.vayusphere.com/products/jabber/"
     },
     {
         "categories": [

--- a/data/software.json
+++ b/data/software.json
@@ -421,8 +421,9 @@
             "server"
         ],
         "doap": null,
-        "name": "djabberd",
+        "name": "DJabberd",
         "platforms": [
+            "FreeBSD",
             "Linux"
         ],
         "url": "https://danga.com"
@@ -1192,6 +1193,7 @@
         "doap": null,
         "name": "Pidgin",
         "platforms": [
+            "BSD",
             "Linux",
             "macOS",
             "Windows"
@@ -1647,7 +1649,7 @@
             "library"
         ],
         "doap": null,
-        "name": "txmmp",
+        "name": "txxmmp",
         "platforms": [
             "Linux"
         ],

--- a/data/software_archive.json
+++ b/data/software_archive.json
@@ -51,7 +51,7 @@
         "platforms": [
             "Windows"
         ],
-        "url": "http://coversant.com"
+        "url": "https://web.archive.org/web/20150912062944/http://www.coversant.com/products/soapbox-communicator"
     },
     {
         "categories": [
@@ -62,7 +62,7 @@
         "platforms": [
             "Windows"
         ],
-        "url": "http://coversant.com"
+        "url": "https://web.archive.org/web/20160112201410/http://www.coversant.com/products/soapbox-server"
     },
     {
         "categories": [
@@ -137,7 +137,7 @@
         "doap": null,
         "name": "IM Observatory",
         "platforms": [],
-        "url": null
+        "url": "https://web.archive.org/web/20221024202306/https://xmpp.net"
     },
     {
         "categories": [
@@ -171,7 +171,7 @@
         "platforms": [
             "Java"
         ],
-        "url": "https://java.net/projects/jso"
+        "url": "https://web.archive.org/web/20160312110355/https://java.net/projects/jso"
     },
     {
         "categories": [
@@ -221,7 +221,7 @@
             "macOS",
             "Windows"
         ],
-        "url": "https://www.jabbim.com"
+        "url": "https://web.archive.org/web/20130122003235/http://dev.jabbim.cz/jabbim/wiki/en/index"
     },
     {
         "categories": [
@@ -233,7 +233,7 @@
             "Linux",
             "Windows"
         ],
-        "url": "http://j-livesupport.com"
+        "url": "https://web.archive.org/web/20220202105402/http://www.j-livesupport.com"
     },
     {
         "categories": [
@@ -277,7 +277,7 @@
         "platforms": [
             "Windows"
         ],
-        "url": "http://www.kwickserver.info/cms/"
+        "url": "https://web.archive.org/web/20190706094016/https://www.kwickserver.info/cms/"
     },
     {
         "categories": [
@@ -299,7 +299,7 @@
         "platforms": [
             "C++"
         ],
-        "url": null
+        "url": "https://web.archive.org/web/20101113053809/http://www.openaether.org/oajabber.html"
     },
     {
         "categories": [
@@ -332,7 +332,7 @@
         "platforms": [
             "Windows"
         ],
-        "url": "http://forum.qip.ru"
+        "url": "https://web.archive.org/web/20180828002258/http://forum.qip.ru"
     },
     {
         "categories": [
@@ -401,7 +401,7 @@
         "platforms": [
             "Mobile"
         ],
-        "url": "http://talkonaut.com"
+        "url": "https://web.archive.org/web/20211226093903/http://talkonaut.com"
     },
     {
         "categories": [

--- a/data/software_archive.json
+++ b/data/software_archive.json
@@ -397,6 +397,18 @@
             "client"
         ],
         "doap": null,
+        "name": "StepChat",
+        "platforms": [
+            "FreeBSD",
+            "Linux"
+        ],
+        "url": "https://github.com/etoile/StepChat"
+    },
+    {
+        "categories": [
+            "client"
+        ],
+        "doap": null,
         "name": "Talkonaut",
         "platforms": [
             "Mobile"
@@ -469,6 +481,17 @@
             "Browser"
         ],
         "url": "https://cgit.babelmonkeys.de/?p=xmppchat.git;a=summary"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "XMPPKit",
+        "platforms": [
+            "Objective-C"
+        ],
+        "url": "https://github.com/etoile/XMPPKit"
     },
     {
         "categories": [

--- a/data/software_archive.json
+++ b/data/software_archive.json
@@ -149,7 +149,7 @@
             "iOS",
             "macOS"
         ],
-        "url": "https://www.shape.ag/en/"
+        "url": "https://www.plus.im"
     },
     {
         "categories": [

--- a/data/software_archive.json
+++ b/data/software_archive.json
@@ -314,6 +314,17 @@
     },
     {
         "categories": [
+            "library"
+        ],
+        "doap": null,
+        "name": "pyxmpp",
+        "platforms": [
+            "Python"
+        ],
+        "url": "https://github.com/Jajcus/pyxmpp"
+    },
+    {
+        "categories": [
             "client"
         ],
         "doap": null,


### PR DESCRIPTION
- Archive deprecated pyxmpp library.
- Rename txmmp to txxmpp and djabberd to DJabberd. Add BSD/FreeBSD as platforms for Pidgin and DJabberd.
- Fix links yet again.
- Bring back online dead websites from the Software Archive thanks to the Wayback Machine (for historical purposes).
- Add [Swift](https://swift.im/swift.html) and [YateClient](https://www.yate.ro/opensource.php?page=yateclient) clients to the Other Software.
- Add a unique GNUstep-based StepChat client ([screenshot](http://etoileos.com/uploads/screenshots/etoile-0.4-stepchat1.png)) for Étoilé DE and its XMPPKit library to the Software Archive.