### PR TITLE
Remove references to inactive/deleted mailing lists

### DIFF
--- a/content/community/mailing-lists.md
+++ b/content/community/mailing-lists.md
@@ -7,17 +7,11 @@ aliases:
 
 There are many active discussion venues for Jabber/XMPP developers, system administrators, and end users. These lists are all easily searchable at [www.mail-archive.com](https://www.mail-archive.com/search?l=all&q=xmpp.org).
 
-### For End Users
-
-__JUser@jabber.org email list__ — for discussion about use of IM clients {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/juser" archives="https://mail.jabber.org/pipermail/juser/" >}}
-
 ### For System Admins
 
 __Operators@xmpp.org email list__ — for discussion about day-to-day operation of the Jabber/XMPP communications network {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/operators" archives="https://mail.jabber.org/pipermail/operators/" >}}
 
 ### For Developers
-
-__JDev@jabber.org email list__ — for discussion about software development using Jabber/XMPP technologies {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/jdev" archives="https://mail.jabber.org/pipermail/jdev/" >}}
 
 __Standards@xmpp.org email list__ — for general discussion about XMPP protocols {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/standards" archives="https://mail.jabber.org/pipermail/standards/" >}}
 
@@ -26,13 +20,5 @@ __xmpp@ietf.org email list__ — official list for [XMPP Working Group](http://t
 ### For Members
 
 __Members@xmpp.org email list__ — official list for members of the XSF. Subscription is available for members only, but the [archives can be found here](https://mail.jabber.org/pipermail/members/).
-
-### Special-Purpose Venues
-
-The following special-purpose mailing lists provide low-volume, high-quality discussion among developers interested in specific aspects of XMPP technologies.
-
-__IOT@xmpp.org email list__ — for discussion about the use of XMPP in the Internet of Things {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/iot" archives="https://mail.jabber.org/pipermail/iot/" >}}
-
-__Security@xmpp.org email list__ — for discussion about security issues related to XMPP, including encryption, authentication, and spam {{< subscribe-archive-block subscribe="https://mail.jabber.org/mailman/listinfo/security" archives="https://mail.jabber.org/pipermail/security/" >}}
 
 All of these venues are completely free and open to any interested individual.


### PR DESCRIPTION
Recently, various mailing lists have been deactivated/removed. This commit removes references to those mailing lists from the website.

Patch by Trung