### PR TITLE
Fix doap URL for Renga

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -1342,7 +1342,7 @@
         "categories": [
             "client"
         ],
-        "doap": "https://pulkomandy.tk/projects/renga/export/main/Renga/doap.xml",
+        "doap": "https://pulkomandy.tk/projects/renga/export/main/doap.xml",
         "name": "Renga",
         "platforms": [],
         "url": null


### PR DESCRIPTION
URL goes through bugtracker export of Git repository and bugtracker configuration was changed.