### PR TITLE
Disable Berlin Sprint announcement

### DIFF
--- a/data/announcement.json
+++ b/data/announcement.json
@@ -1,5 +1,5 @@
 {
-    "enabled": true,
+    "enabled": false,
     "text": "Join the XMPP Sprint Berlin, 23-25 May",
     "url": "https://wiki.xmpp.org/web/Sprints/2025-05_Berlin"
 }


### PR DESCRIPTION
The Sprint has happened. No need to announce it anymore.