### PR TITLE
software.json: add Chatty DOAP

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -294,10 +294,8 @@
         ],
         "doap": "https://gitlab.gnome.org/World/Chatty/-/raw/main/chatty.doap",
         "name": "Chatty",
-        "platforms": [
-            "Linux"
-        ],
-        "url": "https://gitlab.gnome.org/World/Chatty"
+        "platforms": [],
+        "url": null
     },
     {
         "categories": [


### PR DESCRIPTION
The client has DOAP but doesn't specify supported XEPs. I asked devs to add it https://gitlab.gnome.org/World/Chatty/-/issues/983