### PR TITLE
software.json: remove Psi+ as it's just a beta build of Psi

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -1265,15 +1265,6 @@
     },
     {
         "categories": [
-            "client"
-        ],
-        "doap": "https://raw.githubusercontent.com/psi-im/psi/master/psi.doap",
-        "name": "Psi+",
-        "platforms": [],
-        "url": null
-    },
-    {
-        "categories": [
             "server"
         ],
         "doap": null,


### PR DESCRIPTION
The Psi+ long time ago was a fork of Psi but now this project merged and the Psi+ is called by devs as "nightly build". The Psi installable from all distros is built from the Psi+ 