### PR TITLE
More specific link to italian translation of the newsletter

### DIFF
--- a/content/newsletter.md
+++ b/content/newsletter.md
@@ -35,5 +35,5 @@ The XMPP Newsletter is also available in other languages. If you would like to t
 * [Deutsch](https://xmpp.org/categories/newsletter/)
 * [Español](https://xmpp.org/categories/newsletter/)
 * [Français](https://news.jabberfr.org/category/newsletter/)
-* [Italiano](https://notes.nicfab.eu/)
+* [Italiano](https://notes.nicfab.eu/it/newsletter/)
 


### PR DESCRIPTION
Currently the italian translation points to the home page of @nicfab website. I propose to modify the link to the specific section dedicated to the newsletter.