### PR TITLE
Revert link to the italian translation to xmpp.org

### DIFF
--- a/content/newsletter.md
+++ b/content/newsletter.md
@@ -35,5 +35,5 @@ The XMPP Newsletter is also available in other languages. If you would like to t
 * [Deutsch](https://xmpp.org/categories/newsletter/)
 * [Español](https://xmpp.org/categories/newsletter/)
 * [Français](https://news.jabberfr.org/category/newsletter/)
-* [Italiano](https://notes.nicfab.eu/it/newsletter/)
+* [Italiano](https://xmpp.org/categories/newsletter/)
 


### PR DESCRIPTION
Hello, after having discussed with xmpp-it community operators, we decided to revert the global link to the italian translations to xmpp.org itself, which is the common and most complete repository.

We will add links to local versions [nicola's website](https://notes.nicfab.eu/it/newsletter/) till April 2025, and [XMPP-IT Italian Community](https://www.xmpp-it.net/tag/newsletter/) website from May 2025 on) in the translation file.