### PR TITLE
Fix movim account link

### DIFF
--- a/content/blog/newsletter/2025-06-10-newsletter.de.md
+++ b/content/blog/newsletter/2025-06-10-newsletter.de.md
@@ -106,7 +106,7 @@ Letzte Aufrufe (_Last Calls_) erfolgen sobald sich der Status eines XEPs konsoli
 Teile diese Neuigkeiten auch in anderen Netzwerken:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Movim](https://mov.im/blog/xmpp-official)
+- [Movim](https://mov.im/community/news.xmpp.org/Newsletter)
 - [Bluesky](https://bsky.app/profile/xmpp-official.bsky.social)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)

--- a/content/blog/newsletter/2025-06-10-newsletter.it.md
+++ b/content/blog/newsletter/2025-06-10-newsletter.it.md
@@ -105,7 +105,7 @@ Le ultime chiamate vengono emesse quando tutti sembrano soddisfatti dello stato 
 Condividi la notizia su altri social network:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Movim](https://mov.im/blog/xmpp-official)
+- [Movim](https://mov.im/community/news.xmpp.org/Newsletter)
 - [Bluesky](https://bsky.app/profile/xmpp-official.bsky.social)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)

--- a/content/blog/newsletter/2025-06-10-newsletter.md
+++ b/content/blog/newsletter/2025-06-10-newsletter.md
@@ -105,7 +105,7 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Movim](https://mov.im/blog/xmpp-official)
+- [Movim](https://mov.im/community/news.xmpp.org/Newsletter)
 - [Bluesky](https://bsky.app/profile/xmpp-official.bsky.social)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)

--- a/content/blog/newsletter/2025-06-10-newsletter.pt-br.md
+++ b/content/blog/newsletter/2025-06-10-newsletter.pt-br.md
@@ -109,6 +109,7 @@ As últimas chamadas são feitas quando todos parecem satisfeitos com o atual es
 Por favor compartilhe essas notícias em outras plataformas:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
+- [Movim](https://mov.im/community/news.xmpp.org/Newsletter)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)
 - [Instância Lemmy (não oficial)](https://slrpnk.net/c/xmpp)

--- a/content/blog/newsletter/2025-07-05-newsletter.de.md
+++ b/content/blog/newsletter/2025-07-05-newsletter.de.md
@@ -137,7 +137,7 @@ Letzte Aufrufe (_Last Calls_) erfolgen sobald sich der Status eines XEPs konsoli
 Teile diese Neuigkeiten auch in anderen Netzwerken:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Movim](https://mov.im/blog/xmpp-official)
+- [Movim](https://mov.im/community/news.xmpp.org/Newsletter)
 - [Bluesky](https://bsky.app/profile/xmpp-official.bsky.social)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)

--- a/content/blog/newsletter/2025-07-05-newsletter.it.md
+++ b/content/blog/newsletter/2025-07-05-newsletter.it.md
@@ -125,7 +125,7 @@ Le ultime chiamate vengono emesse quando tutti sembrano soddisfatti dello stato 
 Condividi la notizia su altri social network:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Movim](https://mov.im/blog/xmpp-official)
+- [Movim](https://mov.im/community/news.xmpp.org/Newsletter)
 - [Bluesky](https://bsky.app/profile/xmpp-official.bsky.social)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)

--- a/content/blog/newsletter/2025-07-05-newsletter.md
+++ b/content/blog/newsletter/2025-07-05-newsletter.md
@@ -129,7 +129,7 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Movim](https://mov.im/blog/xmpp-official)
+- [Movim](https://mov.im/community/news.xmpp.org/Newsletter)
 - [Bluesky](https://bsky.app/profile/xmpp-official.bsky.social)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)

--- a/content/blog/newsletter/2025-08-05-newsletter.it.md
+++ b/content/blog/newsletter/2025-08-05-newsletter.it.md
@@ -135,7 +135,7 @@ Le ultime chiamate vengono emesse quando tutti sembrano soddisfatti dello stato 
 Condividi la notizia su altri social network:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Movim](https://mov.im/blog/xmpp-official)
+- [Movim](https://mov.im/community/news.xmpp.org/Newsletter)
 - [Bluesky](https://bsky.app/profile/xmpp-official.bsky.social)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)

--- a/content/blog/newsletter/2025-08-05-newsletter.md
+++ b/content/blog/newsletter/2025-08-05-newsletter.md
@@ -135,7 +135,7 @@ Last calls are issued once everyone seems satisfied with the current XEP status.
 Please share the news on other networks:
 
 - [Mastodon](https://fosstodon.org/@xmpp/)
-- [Movim](https://mov.im/blog/xmpp-official)
+- [Movim](https://mov.im/community/news.xmpp.org/Newsletter)
 - [Bluesky](https://bsky.app/profile/xmpp-official.bsky.social)
 - [LinkedIn](https://www.linkedin.com/company/xmpp-standards-foundation/)
 - [YouTube](https://www.youtube.com/channel/UCf3Kq2ElJDFQhYDdjn18RuA)

--- a/themes/xmpp.org/layouts/partials/footer.html
+++ b/themes/xmpp.org/layouts/partials/footer.html
@@ -73,7 +73,7 @@
                         <a href="https://www.linkedin.com/company/xmpp-standards-foundation" target="blank_">@LinkedIn</a>
                     </li>
                     <li>
-                        <a href="https://mov.im/blog/xmpp-official" target="blank_">@Movim</a>
+                        <a href="https://mov.im/community/news.xmpp.org/Newsletter" target="blank_">@Movim</a>
                     </li>
                     <li>
                         <a href="https://bsky.app/profile/xmpp-official.bsky.social" target="blank_">@Bluesky</a>


### PR DESCRIPTION
Now all previous links to the Movim account, that I could find, point to the right direction: https://mov.im/community/news.xmpp.org/Newsletter