### PR TITLE
[ENH] Adding snikket server doap and make it properly listed on xmpp.org

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -1479,10 +1479,12 @@
         "categories": [
             "server"
         ],
-        "doap": null,
+        "doap": "/hosted-doap/snikket-server.doap",
         "name": "Snikket Server",
         "platforms": [
-            "Linux"
+            "Linux",
+            "macOS",
+            "Windows"
         ],
         "url": "https://snikket.org/service/"
     },

--- a/static/hosted-doap/snikket-server.doap
+++ b/static/hosted-doap/snikket-server.doap
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/doap/xmpp-style.xsl" type="text/xsl"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:xmpp="https://linkmauve.fr/ns/xmpp-doap#"
+         xmlns:schema="https://schema.org/"
+         xmlns="http://usefulinc.com/ns/doap#">
+    <Project>
+
+        <name>Snikket Server</name>
+        <short-name>Snikket</short-name>
+
+        <shortdesc xml:lang="en">XMPP Server</shortdesc>
+        <description xml:lang="en">
+            Snikket is an open-source self-hosted personal messaging service. It aims to provide an alternative to proprietary and centralized messaging platforms while supporting all the expected features and being easy to use. The Snikket server lets you create and manage user accounts, and acts as a central safe place to manage your data. Snikket supports multiple devices on a single chat account, it keeps track of which ones are online, and helps deliver messages reliably from person to person.
+        </description>
+
+        <homepage rdf:resource="https://snikket.org/"/>
+        <schema:logo rdf:resource="https://snikket.org/images/logos/snikket-logo.svg"/>
+
+        <download-page rdf:resource="https://snikket.org/service/quickstart/"/>
+        <support-forum rdf:resource="mailto:feedback@snikket.org"/>
+        
+        <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-xmpp"/>
+        <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-jabber"/>
+        <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-server"/>
+        <license rdf:resource="http://usefulinc.com/doap/licenses/asl20"/>
+
+        <programming-language>Lua</programming-language>
+        <os>Linux</os>
+        <os>Windows</os>
+        <os>MacOS</os>
+
+        <repository>
+            <GitRepository>
+                <location rdf:resource="https://github.com/snikket-im/snikket-server.git"/>
+                <browse rdf:resource="https://github.com/snikket-im/snikket-server"/>
+            </GitRepository>
+        </repository>
+    </Project>
+</rdf:RDF>
+
+


### PR DESCRIPTION
### Summary
This MR adds a DOAP (Description of a Project) file for Snikket Server and updates its entry in the software database to enable proper listing in the main filterable software directory on xmpp.org.

### Changes Made
- **Created** `static/hosted-doap/snikket-server.doap` with comprehensive project metadata
- **Updated** `data/software.json` to reference the new DOAP file instead of `null`

### Technical Details
- Added complete DOAP XML with project description, homepage, repository, and platform information
- Updated platforms to reflect actual supported operating systems (Linux, macOS, Windows)

### Impact
- **Before**: Snikket Server only appeared in the collapsed "Other Software" section
- **After**: Snikket Server now appears in the main filterable software list with rich metadata
- Users can now filter and search for Snikket Server alongside other XMPP servers
- Improved discoverability and professional presentation of the project

