### PR TITLE
getting started: remove link to 404.city

### DIFF
--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -40,7 +40,6 @@ Use a [public provider from the curated list of **XMPP Providers**](https://prov
 There are several other (uncurated) lists of providers:
 
 * [Public XMPP servers by jabber.at](https://list.jabber.at)
-* [Open list of public XMPP servers by 404.city](https://xmpp-servers.404.city)
 
 ## 3. Log in! That's it
 


### PR DESCRIPTION
404.city website and services are down. The main page https://404.city indicates that there was a weather event causing catastrophic failure of all their infrastructure. The website is not clear as to when that incident happened (there's date but no year). As of septembre 22, 2025, their infrastructure is still down.

So I removed the link from the list as it's not clear if the services are ever gonna go back up.