### PR TITLE
Include contact information for XSF Members on the website

### DIFF
--- a/themes/xmpp.org/layouts/partials/xsf-diagram-entry.html
+++ b/themes/xmpp.org/layouts/partials/xsf-diagram-entry.html
@@ -1,0 +1,29 @@
+<li class="list-group-item small d-flex justify-content-between align-items-center">
+    <span>
+        {{ .name }}
+        {{ if in .roles "chair" }}
+            (<a href="/about/xsf/people#chair">XSF Chair</a>)
+        {{ end }}
+        {{ if in .roles "ed" }}
+            (<a href="/about/xsf/people#executive-director">Executive Director</a>)
+        {{ end }}
+        {{ if in .roles "secretary" }}
+            (<a href="/about/xsf/people#secretary">Secretary</a>)
+        {{ end }}
+        {{ if in .roles "treasurer" }}
+            (<a href="/about/xsf/people#treasurer">Treasurer</a>)
+        {{ end }}
+    </span>
+    <div class="d-flex gap-2">
+        {{ if .email }}
+            <a href="mailto:{{ index .email 0 | safeURL }}" aria-label="Send mail to {{ .name }}" title="Send mail to {{ .name }}">
+                <i class="fa-regular fa-envelope"></i>
+            </a>
+        {{ end }}
+        {{ if .jids }}
+            <a href="xmpp:{{ index .jids 0 | safeURL }}" aria-label="Chat with {{ .name }}" title="Chat with {{ .name }}">
+                <i class="fa-regular fa-comment-dots"></i>
+            </a>
+        {{ end }}
+    </div>
+</li>

--- a/themes/xmpp.org/layouts/shortcodes/xsf-diagram.html
+++ b/themes/xmpp.org/layouts/shortcodes/xsf-diagram.html
@@ -9,23 +9,9 @@
                 Council
             </div>
             <ul class="list-group list-group-flush">
-                {{ range $members }}
+                {{ range sort $members ".name" }}
                     {{ if in .roles "council" }}
-                        <li class="list-group-item small" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-                            <span>{{ .name }}</span>
-                            <div>
-                                {{ if .email }}
-                                <a href="mailto:{{ index .email 0 | safeURL }}" aria-label="Send mail to {{ .name }}">
-                                    <i class="fa-regular fa-envelope me-2"></i>
-                                </a>
-                                {{ end }}
-                                {{ if .jids }}
-                                <a href="xmpp:{{ index .jids 0 | safeURL }}" aria-label="Chat with {{ .name }}">
-                                    <i class="fa-regular fa-comment-dots me-2"></i>
-                                </a>
-                                {{ end }}
-                            </div>
-                        </li>
+                        {{ partial "xsf-diagram-entry" (dict "name" .name "email" .email "jids" .jids "roles" .roles) }}
                     {{ end }}
                 {{ end }}
             </ul>
@@ -40,61 +26,9 @@
                 Board of Directors
             </div>
             <ul class="list-group list-group-flush">
-                {{ range $members }}
-                    {{ if and (in .roles "board") (in .roles "chair") }}
-                        <li class="list-group-item small" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-                            <span>{{ .name }} <a href="/about/xsf/people#chair">(XSF Chair)</a></span>
-                            <div>
-                                {{ if .email }}
-                                <a href="mailto:{{ index .email 0 | safeURL }}" aria-label="Send mail to {{ .name }}">
-                                    <i class="fa-regular fa-envelope me-2"></i>
-                                </a>
-                                {{ end }}
-                                {{ if .jids }}
-                                <a href="xmpp:{{ index .jids 0 | safeURL }}" aria-label="Chat with {{ .name }}">
-                                    <i class="fa-regular fa-comment-dots me-2"></i>
-                                </a>
-                                {{ end }}
-                            </div>
-                        </li>
-                {{ end }}
-                {{ end }}
-                {{ range $members }}
-                    {{ if and (in .roles "board") (in .roles "ed") }}
-                        <li class="list-group-item small" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-                            <span>{{ .name }} <a href="/about/xsf/people#executive-director">(Executive Director)</a></span>
-                            <div>
-                                {{ if .email }}
-                                <a href="mailto:{{ index .email 0 | safeURL }}" aria-label="Send mail to {{ .name }}">
-                                    <i class="fa-regular fa-envelope me-2"></i>
-                                </a>
-                                {{ end }}
-                                {{ if .jids }}
-                                <a href="xmpp:{{ index .jids 0 | safeURL }}" aria-label="Chat with {{ .name }}">
-                                    <i class="fa-regular fa-comment-dots me-2"></i>
-                                </a>
-                                {{ end }}
-                            </div>
-                        </li>
-                    {{ end }}
-                {{ end }}
-                {{ range $members }}
-                    {{ if and (in .roles "board") (not (in .roles "chair")) (not (in .roles "ed")) }}
-                        <li class="list-group-item small" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-                            <span>{{ .name }}</span>
-                            <div>
-                                {{ if .email }}
-                                <a href="mailto:{{ index .email 0 | safeURL }}" aria-label="Send mail to {{ .name }}">
-                                    <i class="fa-regular fa-envelope me-2"></i>
-                                </a>
-                                {{ end }}
-                                {{ if .jids }}
-                                <a href="xmpp:{{ index .jids 0 | safeURL }}" aria-label="Chat with {{ .name }}">
-                                    <i class="fa-regular fa-comment-dots me-2"></i>
-                                </a>
-                                {{ end }}
-                            </div>
-                        </li>
+                {{ range sort $members ".name" }}
+                    {{ if in .roles "board" }}
+                        {{ partial "xsf-diagram-entry" (dict "name" .name "email" .email "jids" .jids "roles" .roles) }}
                     {{ end }}
                 {{ end }}
             </ul>
@@ -111,80 +45,9 @@
                 XSF Officers
             </div>
             <ul class="list-group list-group-flush">
-                {{ range $members }}
-                    {{ if and (in .roles "board") (in .roles "chair") }}
-                        <li class="list-group-item small" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-                            <span>Chair: <a href="/about/xsf/people#chair">{{ .name }}</a></span>
-                            <div>
-                                {{ if .email }}
-                                <a href="mailto:{{ index .email 0 | safeURL }}" aria-label="Send mail to {{ .name }}">
-                                    <i class="fa-regular fa-envelope me-2"></i>
-                                </a>
-                                {{ end }}
-                                {{ if .jids }}
-                                <a href="xmpp:{{ index .jids 0 | safeURL }}" aria-label="Chat with {{ .name }}">
-                                    <i class="fa-regular fa-comment-dots me-2"></i>
-                                </a>
-                                {{ end }}
-                            </div>
-                        </li>
-                    {{ end }}
-                {{ end }}
-                {{ range $members }}
-                    {{ if in .roles "ed" }}
-                        <li class="list-group-item small" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-                            <span>Executive Director: <a href="/about/xsf/people#executive-director">{{ .name }}</a></span>
-                            <div>
-                                {{ if .email }}
-                                <a href="mailto:{{ index .email 0 | safeURL }}" aria-label="Send mail to {{ .name }}">
-                                    <i class="fa-regular fa-envelope me-2"></i>
-                                </a>
-                                {{ end }}
-                                {{ if .jids }}
-                                <a href="xmpp:{{ index .jids 0 | safeURL }}" aria-label="Chat with {{ .name }}">
-                                    <i class="fa-regular fa-comment-dots me-2"></i>
-                                </a>
-                                {{ end }}
-                            </div>
-                        </li>
-                    {{ end }}
-                {{ end }}
-                {{ range $members }}
-                    {{ if in .roles "secretary" }}
-                        <li class="list-group-item small" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-                            <span>Secretary: <a href="/about/xsf/people#secretary">{{ .name }}</a></span>
-                            <div>
-                                {{ if .email }}
-                                <a href="mailto:{{ index .email 0 | safeURL }}" aria-label="Send mail to {{ .name }}">
-                                    <i class="fa-regular fa-envelope me-2"></i>
-                                </a>
-                                {{ end }}
-                                {{ if .jids }}
-                                <a href="xmpp:{{ index .jids 0 | safeURL }}" aria-label="Chat with {{ .name }}">
-                                    <i class="fa-regular fa-comment-dots me-2"></i>
-                                </a>
-                                {{ end }}
-                            </div>
-                        </li>
-                    {{ end }}
-                {{ end }}
-                {{ range $members }}
-                    {{ if in .roles "treasurer" }}
-                        <li class="list-group-item small" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-                            <span>Treasurer: <a href="/about/xsf/people#treasurer">{{ .name }}</a></span>
-                            <div>
-                                {{ if .email }}
-                                <a href="mailto:{{ index .email 0 | safeURL }}" aria-label="Send mail to {{ .name }}">
-                                    <i class="fa-regular fa-envelope me-2"></i>
-                                </a>
-                                {{ end }}
-                                {{ if .jids }}
-                                <a href="xmpp:{{ index .jids 0 | safeURL }}" aria-label="Chat with {{ .name }}">
-                                    <i class="fa-regular fa-comment-dots me-2"></i>
-                                </a>
-                                {{ end }}
-                            </div>
-                        </li>
+                {{ range sort $members ".name" }}
+                    {{ if or (in .roles "chair") (in .roles "ed") (in .roles "secretary") (in .roles "treasurer")  }}
+                        {{ partial "xsf-diagram-entry" (dict "name" .name "email" .email "jids" .jids "roles" .roles) }}
                     {{ end }}
                 {{ end }}
             </ul>
@@ -209,7 +72,7 @@
                                 Editor team
                             </div>
                             <ul class="list-group list-group-flush">
-                                {{ range $members }}
+                                {{ range sort $members ".name" }}
                                     {{ if in .roles "editor" }}
                                         <li class="list-group-item small">
                                             {{ .name }}
@@ -228,7 +91,7 @@
                                 Infrastructure team
                             </div>
                             <ul class="list-group list-group-flush">
-                                {{ range $members }}
+                                {{ range sort $members ".name" }}
                                     {{ if in .roles "infrastructure" }}
                                         <li class="list-group-item small">
                                             {{ .name }}
@@ -247,7 +110,7 @@
                                 Communication team
                             </div>
                             <ul class="list-group list-group-flush">
-                                {{ range $members }}
+                                {{ range sort $members ".name" }}
                                     {{ if in .roles "commteam" }}
                                         <li class="list-group-item small">
                                             {{ .name }}
@@ -266,7 +129,7 @@
                                 Summits, Conferences, and Meetups team (SCAM)
                             </div>
                             <ul class="list-group list-group-flush">
-                                {{ range $members }}
+                                {{ range sort $members ".name" }}
                                     {{ if in .roles "scam" }}
                                         <li class="list-group-item small">
                                             {{ .name }}


### PR DESCRIPTION
This is an example of how contact information from `members.json` could be used to render contact links, where members are presented on the website.

I know just enough of Hugo, HTML and CSS to be dangerous, but the approach taken here can (and should) be improved by someone who knows what they're doing. I'm committing this as a Proof of Concept. I'm hoping that it is useful for someone to copy/paste relevant bits, but basically redo it, in a proper way.

fixes #1572

This is a screenshot (with some mocked email addresses, as we don't currently have those in `members.json`)

<img width="905" height="1055" alt="image" src="https://github.com/user-attachments/assets/0517f647-e6c1-4ff5-84ec-92c8e3e5a982" />
