### PR TITLE
Add bluesky verification rule to nginx config

### DIFF
--- a/deploy/xsf.conf
+++ b/deploy/xsf.conf
@@ -30,6 +30,12 @@ server {
         default_type text/xml;
     }
 
+    # BlueSky handle verification https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial
+    location = /.well-known/atproto-did {
+        default_type text/plain;
+        return 200 'did:plc:hhyjgh7zxk33uavujv6hypm3';
+    }
+
     add_header Content-Security-Policy "default-src 'self' xmpp.org; style-src 'self' 'unsafe-inline'; img-src * data:; script-src 'self'; connect-src 'self'; object-src 'self'; child-src 'self' xmpp-office-hours.netlify.app; frame-src 'self' xmpp-office-hours.netlify.app; worker-src 'none'; frame-ancestors 'self'; form-action 'self' xmpp-office-hours.netlify.app; upgrade-insecure-requests; block-all-mixed-content";
     add_header Referrer-Policy "strict-origin-when-cross-origin";
 


### PR DESCRIPTION
Fixes #1588 

I tested this by running the Docker image, where /.well-known/atproto-did returned the `did` (served via text/plain).

Details: https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial