### PR TITLE
Use shared data source for sponsors & apply sponsor status changes

### DIFF
--- a/content/community/sponsors/_index.md
+++ b/content/community/sponsors/_index.md
@@ -6,38 +6,8 @@ aliases:
   - "/community/sponsors.html"
 ---
 
-The XSF is generously supported by the sponsors below, please visit their xmpp.org pages (linked below) and sites to say thank you.
+The XSF is generously supported by the sponsors below. Please visit their pages and websites to say thank you.
 
-If your organization would like to become an XSF sponsor, then [please read about the benefits you’ll enjoy](/community/sponsorship).
+If your organization would like to become an XSF sponsor, then [please read about the benefits you'll enjoy](/community/sponsorship).
 
-### ProcessOne
-
-{{< figure src="/images/logos/process-one.png" link="/sponsors/processone" class="p-3 sponsor-logo" >}}
-
-ProcessOne helps its customers build large scale realtime messaging platforms, using standard-based protocols. The company develops ejabberd, one of the most popular XMPP server. ejabberd is highly customizable and powers some of the largest messaging services & IoT platforms. Easy to deploy for small community servers, it scales massively and supports clustering, with the ability to support hundreds of millions users in a single domain.
-
-[More about ProcessOne](/sponsors/processone)
-
-### Tigase
-
-{{< figure src="/images/logos/tigase.png" link="/sponsors/tigase" class="p-3 sponsor-logo" >}}
-
-Tigase, Inc. is a leading provider of customized implementations of XMPP-based software. Written in Java, Tigase XMPP Server can run on any hardware supporting the Java Development Kit, and can easily scale from small single machine installations to millions of users on a clustered network.
-
-[More about Tigase](/sponsors/tigase)
-
-### Tygrys
-
-{{< figure src="/images/logos/tygrys.png" link="/sponsors/tygrys" class="p-3 sponsor-logo" >}}
-
-Tygrys is an expansive tech suite crafted to deliver secure and efficient communication for individuals and teams. Integrating our XMPP service supplemented with a hand-made multi-platform XMPP client, email service, and comprehensive project and code management tools, the suite is designed from the ground up for seamless operation across multiple platforms. By prioritizing user privacy, Tygrys ensures that personal data remains strictly in the hands of its users, with our staunch commitment to having no data to collect and nothing to track.
-
-[More about Tygrys](/sponsors/tygrys)
-
-### US Secure Hosting Center
-
-{{< figure src="/images/logos/usshc.png" link="/sponsors/us-secure-hosting-center" class="p-3 sponsor-logo" >}}
-
-USSHC is a privately owned underground secure colocation data center located in the rural Midwestern United States.
-
-[More about USSHC](/sponsors/us-secure-hosting-center)
+{{< sponsors >}}

--- a/content/community/sponsors/tigase.md
+++ b/content/community/sponsors/tigase.md
@@ -7,32 +7,15 @@ aliases:
 
 {{< figure src="/images/logos/tigase.png" class="p-3 sponsor-logo w-100 text-center" >}}
 
-Tigase is home to Tigase XMPP Server, Tigase JaXMPP Client library, Tigase Messenger for Android and iOS, and other XMPP-related projects.  We specialize in creating robust, secure, and reliable XMPP-based real time communication systems.  Tigase provides agility and the freedom to scale projects and installations from small one-office networks to hundreds of thousands of connected users to a clustered network.
+> **Note:** Tigase is no longer an active sponsor at a level that includes a dedicated page on the XMPP Standards Foundation website.
+> This page is preserved for historical reference.
 
-Tigase XMPP Server is our flagship product providing instant communication services using the XMPP protocol. Tigase is unique in open source XMPP software:
+The XSF gratefully acknowledges the past support of **[Tigase](http://www.tigase.net)**, who have contributed to the XMPP ecosystem and supported the Foundation.
 
-### Unmatched Flexibility:
+Tigase develops a range of XMPP-based technologies, including Tigase XMPP Server, JaXMPP client libraries, and mobile messaging solutions. Their work has focused on enabling scalable, flexible, and secure real-time communication systems for a variety of use cases.
 
-Our software is easy to configure, and can be done on the fly without server restart. Tigase can be customized with available extensions, or custom code to fit your needs.
+The XSF thanks Tigase for their contributions to the XMPP community and wishes them continued success.
 
-### Highly Optimized:
+---
 
-Small footprint on servers, and can run on anything that supports JDK v8.
-
-### Easy scripting support:
-
-Tigase can support scripts such as Java, Groovy, Python, Ruby, and Scala.  You won’t need to learn another language to customize scripts to have Tigase do exactly what you want.
-
-### Clustering support:
-
-Many open source XMPP servers support clustering, but Tigase can cluster out of the box with a single configuration change!  Quickly grow and expand your server potential without hassle.
-
-### Security minded:
-
-Want to keep your servers secure?  Tigase supports authentication from SASL-PLAIN to SCRAM-SHA-PLUS-1, and features a one-line hardened mode setting that forces the highest level of security for your XMPP server.
-
-Looking to embed a low footprint chat client to match your XMPP server needs?  Look no further than Tigase’s JaXMPP client library.  This library can be deployed on any environment running Java, and can be used in Android mobile devices.  This library is an easy way to standardize communication on your network by having the same look and feel for every device to keep training costs down.  This library can be customized to fit a branded environment to maintain that bespoke corporate look.
-
-Explore options with our development team who can design and code custom solutions for your installation.  We know that no two installations are alike and outside phenomenal help for setup, we offer custom extensions.  These can be coded specifically for you in your environment.  Our customers have employed Tigase XMPP Server and related products in a wide variety of use cases & scenarios; from simple chat servers to highly complex networks serving media to thousands of customers.
-
-These are just a few of the services we offer, and but a tiny fraction of the benefits our services can provide.  Visit [www.tigase.net](http://www.tigase.net) today to explore our products, and see how we can build to suit your instant communication needs.
+*Interested in supporting the XMPP Standards Foundation? Visit our [sponsorship page](/sponsor/) to learn how.*

--- a/content/community/sponsors/tygrys.md
+++ b/content/community/sponsors/tygrys.md
@@ -7,26 +7,15 @@ aliases:
 
 {{< figure src="/images/logos/tygrys.png" class="p-3 sponsor-logo w-100 text-center" >}}
 
-Tygrys is an expansive tech suite crafted to deliver secure and efficient communication for individuals and teams. Integrating our XMPP service supplemented with a hand-made multi-platform XMPP client, email service, and comprehensive project and code management tools, the suite is designed from the ground up for seamless operation across multiple platforms. By prioritizing user privacy, Tygrys ensures that personal data remains strictly in the hands of its users, with our staunch commitment to having no data to collect and nothing to track.
+> **Note:** Tygrys is no longer an active sponsor at a level that includes a dedicated page on the XMPP Standards Foundation website.
+> This page is preserved for historical reference.
 
-### XMPP Service
+The XSF gratefully acknowledges the past support of **[Tygrys](http://tygrys.one)**, who contributed to the XMPP ecosystem and supported the Foundation.
 
-The Tygrys suite is centered around our powerful XMPP service, ensuring stable and secure communication. As the cornerstone of our platform, our service based on Tigase’s XMPP server guarantees high reliability and performance for all types of communication, be it private or large group chats. We are committed to continuously enhancing security, regularly implementing stronger measures to safeguard your conversations.
+Tygrys develops an integrated suite of communication and collaboration tools centered around XMPP, alongside complementary services such as email and project management. Their focus on privacy, security, and cross-platform usability reflects the broader goals of the XMPP community.
 
-In addition to the XMPP service is the Tygrys Multi-platform XMPP client. Our client seamlessly connects you securely to others, across Android, Windows, MacOS, Linux, and Web. your private and group chats are safe, ensuring that every message sent and document shared is for your eyes only. The client boasts an array of features, including customizable theming, an emoji picker, file sharing, and much more, enhancing your communication experience without compromising security.
+The XSF thanks Tygrys for their contributions to the XMPP community and wishes them continued success.
 
-However, the Tygrys XMPP service is fully XMPP compliant, so you can use any other preferred client as well!
+---
 
-### E-Mailing Service
-
-Complementing the XMPP system is our email service, which adheres to the same high standards of security and privacy. Using the open source software Apache James, and being compatible with IMAP/SMTP protocols, it provides a reliable platform for managing your emails. This service is designed to streamline your email workflow, offering many modern features, with more to come.
-
-### Code and Project Management
-
-For professionals managing projects and code, our suite includes comprehensive tools that support HTTPS, SSH, and Git protocols. Utilizing the open-source tool OneDev, we simplify project oversight, from task assignments to deadline tracking, while providing a secure environment for code repository management, version control, and collaborative coding.
-
-### With much, much more.
-
-Tygrys is continually evolving, with a commitment to introducing new features that respond to the needs of our users. With an active support team ready to assist, Tygrys stands as a dynamic and dependable partner in your secure communications.
-
-You can start today, and read more at [tygrys.one](https://tygrys.one/)
+*Interested in supporting the XMPP Standards Foundation? Visit our [sponsorship page](/sponsor/) to learn how.*

--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -1,0 +1,34 @@
+{
+  "titanium": [
+  ],
+  "platinum": [
+  ],
+  "gold": [
+    {
+      "name": "ProcessOne",
+      "slug": "processone",
+      "logo": "/images/logos/process-one.png",
+      "description": "ProcessOne helps its customers build large scale realtime messaging platforms, using standard-based protocols. The company develops ejabberd, one of the most popular XMPP server. ejabberd is highly customizable and powers some of the largest messaging services & IoT platforms. Easy to deploy for small community servers, it scales massively and supports clustering, with the ability to support hundreds of millions users in a single domain."
+    },
+    {
+      "name": "Tigase",
+      "slug": "tigase",
+      "logo": "/images/logos/tigase.png",
+      "description": "Tigase, Inc. is a leading provider of customized implementations of XMPP-based software. Written in Java, Tigase XMPP Server can run on any hardware supporting the Java Development Kit, and can easily scale from small single machine installations to millions of users on a clustered network."
+    },
+    {
+      "name": "Tygrys",
+      "slug": "tygrys",
+      "logo": "/images/logos/tygrys.png",
+      "description": "Tygrys is an expansive tech suite crafted to deliver secure and efficient communication for individuals and teams. Integrating our XMPP service supplemented with a hand-made multi-platform XMPP client, email service, and comprehensive project and code management tools, the suite is designed from the ground up for seamless operation across multiple platforms. By prioritizing user privacy, Tygrys ensures that personal data remains strictly in the hands of its users, with our staunch commitment to having no data to collect and nothing to track."
+    },
+    {
+      "name": "US Secure Hosting Center",
+      "slug": "us-secure-hosting-center",
+      "logo": "/images/logos/usshc.png",
+      "description": "USSHC is a privately owned underground secure colocation data center located in the rural Midwestern United States."
+    }
+  ],
+  "silver": [
+  ]
+}

--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -30,5 +30,9 @@
     }
   ],
   "silver": [
+    {
+      "name": "Extensible Messaging Ltd",
+      "logo": "/images/logos/extensible-messaging-ltd.svg"
+    }
   ]
 }

--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -11,18 +11,6 @@
       "description": "ProcessOne helps its customers build large scale realtime messaging platforms, using standard-based protocols. The company develops ejabberd, one of the most popular XMPP server. ejabberd is highly customizable and powers some of the largest messaging services & IoT platforms. Easy to deploy for small community servers, it scales massively and supports clustering, with the ability to support hundreds of millions users in a single domain."
     },
     {
-      "name": "Tigase",
-      "slug": "tigase",
-      "logo": "/images/logos/tigase.png",
-      "description": "Tigase, Inc. is a leading provider of customized implementations of XMPP-based software. Written in Java, Tigase XMPP Server can run on any hardware supporting the Java Development Kit, and can easily scale from small single machine installations to millions of users on a clustered network."
-    },
-    {
-      "name": "Tygrys",
-      "slug": "tygrys",
-      "logo": "/images/logos/tygrys.png",
-      "description": "Tygrys is an expansive tech suite crafted to deliver secure and efficient communication for individuals and teams. Integrating our XMPP service supplemented with a hand-made multi-platform XMPP client, email service, and comprehensive project and code management tools, the suite is designed from the ground up for seamless operation across multiple platforms. By prioritizing user privacy, Tygrys ensures that personal data remains strictly in the hands of its users, with our staunch commitment to having no data to collect and nothing to track."
-    },
-    {
       "name": "US Secure Hosting Center",
       "slug": "us-secure-hosting-center",
       "logo": "/images/logos/usshc.png",
@@ -33,6 +21,18 @@
     {
       "name": "Extensible Messaging Ltd",
       "logo": "/images/logos/extensible-messaging-ltd.svg"
+    },
+    {
+      "name": "Tigase",
+      "slug": "tigase",
+      "logo": "/images/logos/tigase.png",
+      "description": "Tigase, Inc. is a leading provider of customized implementations of XMPP-based software. Written in Java, Tigase XMPP Server can run on any hardware supporting the Java Development Kit, and can easily scale from small single machine installations to millions of users on a clustered network."
+    },
+    {
+      "name": "Tygrys",
+      "slug": "tygrys",
+      "logo": "/images/logos/tygrys.png",
+      "description": "Tygrys is an expansive tech suite crafted to deliver secure and efficient communication for individuals and teams. Integrating our XMPP service supplemented with a hand-made multi-platform XMPP client, email service, and comprehensive project and code management tools, the suite is designed from the ground up for seamless operation across multiple platforms. By prioritizing user privacy, Tygrys ensures that personal data remains strictly in the hands of its users, with our staunch commitment to having no data to collect and nothing to track."
     }
   ]
 }

--- a/static/images/logos/extensible-messaging-ltd.svg
+++ b/static/images/logos/extensible-messaging-ltd.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="550"
+   height="180"
+   version="1.1"
+   id="svg24"
+   sodipodi:docname="eml-logotype.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs28" />
+  <sodipodi:namedview
+     id="namedview26"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="3.125"
+     inkscape:cx="269.28"
+     inkscape:cy="113.76"
+     inkscape:window-width="3072"
+     inkscape:window-height="1656"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg24">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2360"
+       originx="-4.5"
+       originy="-4.5"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <!-- Khaki speech bubble -->
+  <path
+     d="m 10.5,0.5 h 99.99999 A 9.9999995,10 0 0 1 120.5,10.5 v 40 a 9.9999995,10 0 0 1 -10.00001,10 H 50.499998 l -15.000001,15 v -15 H 10.5 a 9.9999995,10 0 0 1 -10,-10 v -40 a 9.9999995,10 0 0 1 10,-10 z"
+     fill="#b5a27d"
+     id="path2"
+     style="stroke:#fffbfb;stroke-width:1;stroke-opacity:1" />
+  <!-- Teal speech bubble overlapping -->
+  <!-- Company name -->
+  <path
+     d="M 170.0897,50.992373 H 70.910313 a 9.917939,9.7774717 0 0 0 -9.917939,9.777472 V 99.87973 a 9.917939,9.7774717 0 0 0 9.917939,9.77747 h 59.507627 l 14.87692,14.66621 V 109.6572 h 24.79484 a 9.917939,9.7774717 0 0 0 9.91793,-9.77747 V 60.769845 a 9.917939,9.7774717 0 0 0 -9.91793,-9.777472 z"
+     fill="#2bb3a3"
+     id="path188"
+     style="stroke:#fffbfb;stroke-width:0.984747;stroke-opacity:1" />
+  <g
+     id="g882"
+     transform="translate(-14.343046,-20.975781)"
+     inkscape:label="speech-khaki">
+    <circle
+       cx="40.308281"
+       cy="51.503395"
+       r="5"
+       fill="#333333"
+       id="circle12"
+       style="fill:#ffffff;fill-opacity:1" />
+    <circle
+       cx="60.308281"
+       cy="51.503395"
+       r="5"
+       fill="#333333"
+       id="circle14"
+       style="fill:#ffffff;fill-opacity:1" />
+    <circle
+       cx="80.308281"
+       cy="51.503395"
+       r="5"
+       fill="#333333"
+       id="circle16"
+       style="fill:#ffffff;fill-opacity:1" />
+    <circle
+       cx="99.316093"
+       cy="51.580074"
+       r="5"
+       fill="#333333"
+       id="circle876"
+       style="fill:#ffffff;fill-opacity:1" />
+  </g>
+  <g
+     id="g902"
+     transform="matrix(0.98980844,0,0,0.97774717,50.551566,30.031437)"
+     inkscape:label="speech-med">
+    <circle
+       cx="40.308281"
+       cy="51.503395"
+       r="5"
+       fill="#333333"
+       id="circle894"
+       style="fill:#ffffff;fill-opacity:1" />
+    <circle
+       cx="60.308281"
+       cy="51.503395"
+       r="5"
+       fill="#333333"
+       id="circle896"
+       style="fill:#ffffff;fill-opacity:1" />
+    <circle
+       cx="80.308281"
+       cy="51.503395"
+       r="5"
+       fill="#333333"
+       id="circle898"
+       style="fill:#ffffff;fill-opacity:1" />
+    <circle
+       cx="99.316093"
+       cy="51.580074"
+       r="5"
+       fill="#333333"
+       id="circle900"
+       style="fill:#ffffff;fill-opacity:1" />
+  </g>
+  <path
+     d="m 10.5,100.5 h 100 a 9.9999999,9.9999997 0 0 1 10,10 v 39.99999 a 9.9999999,9.9999997 0 0 1 -10,10 h -60 l -14.999999,15 v -15 H 10.5 a 9.9999999,9.9999997 0 0 1 -10,-10 V 110.5 a 9.9999999,9.9999997 0 0 1 10,-10 z"
+     fill="#2bb3a3"
+     id="path10"
+     style="fill:#565656;fill-opacity:1;stroke:#fffbfb;stroke-width:1;stroke-opacity:1" />
+  <g
+     id="g892"
+     transform="translate(-14.655312,79.023301)"
+     inkscape:label="speech-grey">
+    <circle
+       cx="40.308281"
+       cy="51.503395"
+       r="5"
+       fill="#333333"
+       id="circle884"
+       style="fill:#ffffff;fill-opacity:1" />
+    <circle
+       cx="60.308281"
+       cy="51.503395"
+       r="5"
+       fill="#333333"
+       id="circle886"
+       style="fill:#ffffff;fill-opacity:1" />
+    <circle
+       cx="80.308281"
+       cy="51.503395"
+       r="5"
+       fill="#333333"
+       id="circle888"
+       style="fill:#ffffff;fill-opacity:1" />
+    <circle
+       cx="99.316093"
+       cy="51.580074"
+       r="5"
+       fill="#333333"
+       id="circle890"
+       style="fill:#ffffff;fill-opacity:1" />
+  </g>
+  <text
+     xml:space="preserve"
+     style="text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;fill-opacity:1"
+     x="189.75999"
+     y="68.479996"
+     id="text1"><tspan
+       sodipodi:role="line"
+       id="tspan1"
+       x="189.75999"
+       y="68.479996"
+       style="font-style:oblique;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:74.6667px;font-family:FreeSans;-inkscape-font-specification:'FreeSans, Oblique';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;display:inline;fill:#000000;fill-opacity:1"
+       inkscape:label="extensible">Extensible</tspan></text>
+  <text
+     xml:space="preserve"
+     style="text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;fill-opacity:1"
+     x="189.54666"
+     y="157.03189"
+     id="text1-4"
+     inkscape:label="messaging"><tspan
+       sodipodi:role="line"
+       x="189.54666"
+       y="157.03189"
+       style="font-style:oblique;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:74.6667px;font-family:FreeSans;-inkscape-font-specification:'FreeSans, Oblique';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1"
+       id="tspan2-0">Messaging</tspan></text>
+</svg>

--- a/themes/xmpp.org/assets/css/style.css
+++ b/themes/xmpp.org/assets/css/style.css
@@ -451,6 +451,8 @@ button[name="show-xep-implementations"] {
 .sponsors-titanium,
 .sponsors-platinum,
 .sponsors-gold {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
     display: flex;
     flex-direction: column;
     gap: 2rem;
@@ -472,15 +474,17 @@ button[name="show-xep-implementations"] {
 }
 
 .sponsors-silver {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     gap: 1.5rem;
     justify-items: center;
     align-items: center;
 }
 
 .sponsors-silver img {
-    max-width: 120px;
+    max-width: 160px;
     height: auto;
     opacity: 0.9;
 }

--- a/themes/xmpp.org/assets/css/style.css
+++ b/themes/xmpp.org/assets/css/style.css
@@ -447,6 +447,45 @@ button[name="show-xep-implementations"] {
 }
 
 
+/* Sponsors */
+.sponsors-titanium,
+.sponsors-platinum,
+.sponsors-gold {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.sponsor {
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
+}
+
+.sponsor-logo img {
+    max-width: 160px;
+    height: auto;
+}
+
+.sponsor-content {
+    flex: 1;
+}
+
+.sponsors-silver {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1.5rem;
+    justify-items: center;
+    align-items: center;
+}
+
+.sponsors-silver img {
+    max-width: 120px;
+    height: auto;
+    opacity: 0.9;
+}
+
+
 /* Dark theme */
 @media (prefers-color-scheme: dark) {
 	label {

--- a/themes/xmpp.org/layouts/partials/footer.html
+++ b/themes/xmpp.org/layouts/partials/footer.html
@@ -30,7 +30,7 @@
 
         {{ range $sponsors.silver }}
         <li>
-            <a href="/sponsors/{{ .slug }}/">
+            <a href="/community/sponsors/">
                 <img src="{{ .logo }}" alt="{{ .name }}">
             </a>
         </li>

--- a/themes/xmpp.org/layouts/partials/footer.html
+++ b/themes/xmpp.org/layouts/partials/footer.html
@@ -1,12 +1,45 @@
 <div class="footer-sponsors text-center p-5">
-    <h4>The <a href="/about/xmpp-standards-foundation/">XSF</a> is generously sponsored by:</h4>
+    <h4> The <a href="/about/xmpp-standards-foundation/">XSF</a> is generously sponsored by:</h4>
+
+    {{ $sponsors := site.Data.sponsors }}
+
     <ul>
-        <li><a href="/sponsors/processone/"><img src="/images/logos/process-one.png" alt="ProcessOne"></a></li>
-        <li><a href="/sponsors/tigase/"><img src="/images/logos/tigase.png" alt="Tigase"></a></li>
-        <li><a href="/sponsors/tygrys/"><img src="/images/logos/tygrys.png" alt="Tygrys"></a></li>
-        <li><a href="/sponsors/us-secure-hosting-center/"><img src="/images/logos/usshc.png" alt="US Secure Hosting Center"></a></li>
+        {{ range $sponsors.titanium }}
+        <li>
+            <a href="/sponsors/{{ .slug }}/">
+                <img src="{{ .logo }}" alt="{{ .name }}">
+            </a>
+        </li>
+        {{ end }}
+
+        {{ range $sponsors.platinum }}
+        <li>
+            <a href="/sponsors/{{ .slug }}/">
+                <img src="{{ .logo }}" alt="{{ .name }}">
+            </a>
+        </li>
+        {{ end }}
+
+        {{ range $sponsors.gold }}
+        <li>
+            <a href="/sponsors/{{ .slug }}/">
+                <img src="{{ .logo }}" alt="{{ .name }}">
+            </a>
+        </li>
+        {{ end }}
+
+        {{ range $sponsors.silver }}
+        <li>
+            <a href="/sponsors/{{ .slug }}/">
+                <img src="{{ .logo }}" alt="{{ .name }}">
+            </a>
+        </li>
+        {{ end }}
     </ul>
-    <a href="/community/sponsorship/" class="p-2 border rounded">Become a sponsor</a>
+
+    <a href="/community/sponsorship/" class="p-2 border rounded">
+        Become a sponsor
+    </a>
 </div>
 <div class="footer-github">
     <p>

--- a/themes/xmpp.org/layouts/partials/sponsors.html
+++ b/themes/xmpp.org/layouts/partials/sponsors.html
@@ -73,9 +73,9 @@
 <h2>Silver Sponsors</h2>
 <div class="sponsors-silver">
     {{ range $sponsors.silver }}
-    <a href="/sponsors/{{ .slug }}" class="sponsor-logo">
+    <div class="sponsor-logo">
         <img src="{{ .logo }}" alt="{{ .name }}">
-    </a>
+    </div>
     {{ end }}
 </div>
 {{ end }}

--- a/themes/xmpp.org/layouts/partials/sponsors.html
+++ b/themes/xmpp.org/layouts/partials/sponsors.html
@@ -1,0 +1,81 @@
+{{ $sponsors := site.Data.sponsors }}
+
+{{ if $sponsors.titanium }}
+<h2>Titanium Sponsors</h2>
+<div class="sponsors-titanium">
+    {{ range $sponsors.titanium }}
+    <div class="sponsor">
+        <div class="sponsor-logo">
+            <a href="/sponsors/{{ .slug }}">
+                <img src="{{ .logo }}" alt="{{ .name }}">
+            </a>
+        </div>
+
+        <div class="sponsor-content">
+            <h3>{{ .name }}</h3>
+            {{ if .description }}
+            <p>{{ .description }}</p>
+            {{ end }}
+            <a href="/sponsors/{{ .slug }}">More about {{ .name }}</a>
+        </div>
+    </div>
+    {{ end }}
+</div>
+{{ end }}
+
+{{ if $sponsors.platinum }}
+<h2>Platinum Sponsors</h2>
+<div class="sponsors-platinum">
+    {{ range $sponsors.platinum }}
+    <div class="sponsor">
+        <div class="sponsor-logo">
+            <a href="/sponsors/{{ .slug }}">
+                <img src="{{ .logo }}" alt="{{ .name }}">
+            </a>
+        </div>
+
+        <div class="sponsor-content">
+            <h3>{{ .name }}</h3>
+            {{ if .description }}
+            <p>{{ .description }}</p>
+            {{ end }}
+            <a href="/sponsors/{{ .slug }}">More about {{ .name }}</a>
+        </div>
+    </div>
+    {{ end }}
+</div>
+{{ end }}
+
+{{ if $sponsors.gold }}
+<h2>Gold Sponsors</h2>
+<div class="sponsors-gold">
+    {{ range $sponsors.gold }}
+    <div class="sponsor">
+        <div class="sponsor-logo">
+            <a href="/sponsors/{{ .slug }}">
+                <img src="{{ .logo }}" alt="{{ .name }}">
+            </a>
+        </div>
+
+        <div class="sponsor-content">
+            <h3>{{ .name }}</h3>
+            {{ if .description }}
+                <p>{{ .description }}</p>
+            {{ end }}
+            <a href="/sponsors/{{ .slug }}">More about {{ .name }}</a>
+        </div>
+    </div>
+    {{ end }}
+</div>
+{{ end }}
+
+{{ if $sponsors.silver }}
+<h2>Silver Sponsors</h2>
+<div class="sponsors-silver">
+    {{ range $sponsors.silver }}
+    <a href="/sponsors/{{ .slug }}" class="sponsor-logo">
+        <img src="{{ .logo }}" alt="{{ .name }}">
+    </a>
+    {{ end }}
+</div>
+{{ end }}

--- a/themes/xmpp.org/layouts/shortcodes/sponsors.html
+++ b/themes/xmpp.org/layouts/shortcodes/sponsors.html
@@ -1,0 +1,1 @@
+{{ partial "sponsors.html" . }}


### PR DESCRIPTION
This switches to using a common data source, rather than hard-coding data for sponsors on various pages. From this data, the footer and page that lists all sponsors is populated.

The page that lists all sponsors is modified to differentiate between the various levels of sponsors.

Only the longer descriptive texts for gold sponsors are not included in the re-usable data.