### PR TITLE
Add Ethora to software list

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -491,9 +491,9 @@
         "doap": null,
         "name": "Ethora",
         "platforms": [
-            "JavaScript",
             "Android",
-            "iOS"
+            "iOS",
+            "JavaScript"
         ],
         "url": "https://ethora.com"
     },

--- a/data/software.json
+++ b/data/software.json
@@ -485,6 +485,20 @@
     },
     {
         "categories": [
+            "integrated-platform",
+            "library"
+        ],
+        "doap": null,
+        "name": "Ethora",
+        "platforms": [
+            "JavaScript",
+            "Android",
+            "iOS"
+        ],
+        "url": "https://ethora.com"
+    },
+    {
+        "categories": [
             "tool"
         ],
         "doap": "/hosted-doap/explore-xep-0392-consistent-color-generation.doap",


### PR DESCRIPTION
Adds [Ethora](https://ethora.com) to `data/software.json`.

Ethora is an open-source XMPP-based chat & messaging platform with SDKs for React, native iOS/Android, and WordPress, plus an AI agent / chatbot framework. The server side is built on ejabberd.

- Categories: `integrated-platform`, `library`
- Platforms: JavaScript, Android, iOS
- URL: https://ethora.com
- Source: https://github.com/dappros/ethora (Apache-2.0)
- DOAP: not yet published — happy to follow up with one if helpful.

Inserted alphabetically between `Escalus` and the next entry.