### PR TITLE
Enable annoucement for Summit 29

### DIFF
--- a/data/announcement.json
+++ b/data/announcement.json
@@ -1,5 +1,5 @@
 {
-    "enabled": false,
-    "text": "XMPP Summit 28 - Join us in Brussels, 29th - 30th Jan 2026",
-    "url": "https://xmpp.org/2025/11/xmpp-summit-28/"
+    "enabled": true,
+    "text": "XMPP Summit 29 - Join us online on 4th - 5th Sep 2026",
+    "url": "https://wiki.xmpp.org/web/Conferences/Summit_29"
 }


### PR DESCRIPTION
This enables the announcement on the front page of the website, pointing at the Wiki page for Summit 29.