### PR TITLE
Add Teletyptel 2.0 to software directory

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -1621,6 +1621,19 @@
     },
     {
         "categories": [
+            "client"
+        ],
+        "doap": null,
+        "name": "Teletyptel 2.0",
+        "platforms": [
+            "Android",
+            "iOS",
+            "Web"
+        ],
+        "url": "https://github.com/edwtie/Tiedragon.XmppMessenger"
+    },
+    {
+        "categories": [
             "server"
         ],
         "doap": "https://raw.githubusercontent.com/tigase/tigase-server/master/tigase-server.doap",


### PR DESCRIPTION
Adds Teletyptel 2.0 as a web-first XMPP client entry.

Teletyptel 2.0 is an accessible realtime communication client focused on standard chat and XEP-0301 real-time text, with Android and iOS packaging planned from the same web client direction.

Validation:

- `python ./src/lint_software_list.py ./data/software.json`