### PR TITLE
Ethora: link to upstream DOAP file

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -488,7 +488,7 @@
             "integrated-platform",
             "library"
         ],
-        "doap": null,
+        "doap": "https://raw.githubusercontent.com/dappros/ethora/main/doap.xml",
         "name": "Ethora",
         "platforms": [
             "Android",

--- a/data/software.json
+++ b/data/software.json
@@ -490,12 +490,8 @@
         ],
         "doap": "https://raw.githubusercontent.com/dappros/ethora/main/doap.xml",
         "name": "Ethora",
-        "platforms": [
-            "Android",
-            "iOS",
-            "JavaScript"
-        ],
-        "url": "https://ethora.com"
+        "platforms": [],
+        "url": null
     },
     {
         "categories": [


### PR DESCRIPTION
Follow-up to #1675 (Add Ethora to software list).

The Ethora repo now ships a DOAP file at https://raw.githubusercontent.com/dappros/ethora/main/doap.xml, so this fills in the previously-`null` `doap` field on the Ethora entry in `data/software.json`.

Per @guusdk's suggestion in #1675, this should improve how Ethora is rendered on xmpp.org.

cc @cal0pteryx @guusdk