### PR TITLE
Add Livewire (Ubuntu Touch Client)

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -978,6 +978,15 @@
     },
     {
         "categories": [
+            "client"
+        ],
+        "doap": "https://git.agnos.is/projectmoon/livewire/raw/branch/master/doap.xml",
+        "name": "Livewire",
+        "platforms": [],
+        "url": null
+    },
+    {
+        "categories": [
             "library"
         ],
         "doap": null,


### PR DESCRIPTION
I've been working on an XMPP client for Ubuntu Touch, and I now think it's ready enough to be on the list of clients.