### PR TITLE
Software: Update jabber.el DOAP URL to new repository

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -711,7 +711,7 @@
         "categories": [
             "client"
         ],
-        "doap": "https://codeberg.org/emacs-jabber/emacs-jabber/raw/branch/master/doap.xml",
+        "doap": "https://git.thanosapollo.org/emacs-jabber/plain/doap.xml",
         "name": "jabber.el",
         "platforms": [],
         "url": null


### PR DESCRIPTION
The jabber.el repository has moved from Codeberg to `git.thanosapollo.org`. 

*Hopefully, the last migration we’ll ever need.*