### PR TITLE
Add Artalk.Xmpp library metadata

### DIFF
--- a/content/about/technology-overview.md
+++ b/content/about/technology-overview.md
@@ -139,6 +139,7 @@ __Clients__
 
 __Libraries__
 
+- [Artalk.Xmpp](https://github.com/araditc/Artalk.Xmpp) (.NET)
 - [gloox](https://camaya.net/gloox) (C++)
 - [libpurple](https://developer.pidgin.im/wiki/WhatIsLibpurple) (C)
 - [Smack](http://www.igniterealtime.org/projects/smack/index.jsp) (Java)
@@ -237,6 +238,7 @@ The following standalone XMPP connection managers can be used with a wide variet
 
 #### Libraries
 
+- [Artalk.Xmpp](https://github.com/araditc/Artalk.Xmpp) (.NET)
 - [gloox](https://camaya.net/gloox) (C++)
 - [strophe](https://strophe.im/) (C or JavaScript)
 - [Swiften](https://swift.im/swiften.html) (C++)

--- a/content/about/technology-overview.md
+++ b/content/about/technology-overview.md
@@ -139,7 +139,7 @@ __Clients__
 
 __Libraries__
 
-- [Artalk.Xmpp](https://github.com/araditc/Artalk.Xmpp) (.NET)
+- [Artalk.Xmpp](https://github.com/araditc/Artalk.Xmpp) (.NET 10)
 - [gloox](https://camaya.net/gloox) (C++)
 - [libpurple](https://developer.pidgin.im/wiki/WhatIsLibpurple) (C)
 - [Smack](http://www.igniterealtime.org/projects/smack/index.jsp) (Java)
@@ -238,7 +238,7 @@ The following standalone XMPP connection managers can be used with a wide variet
 
 #### Libraries
 
-- [Artalk.Xmpp](https://github.com/araditc/Artalk.Xmpp) (.NET)
+- [Artalk.Xmpp](https://github.com/araditc/Artalk.Xmpp) (.NET 10)
 - [gloox](https://camaya.net/gloox) (C++)
 - [strophe](https://strophe.im/) (C or JavaScript)
 - [Swiften](https://swift.im/swiften.html) (C++)

--- a/data/software.json
+++ b/data/software.json
@@ -79,9 +79,7 @@
         ],
         "doap": "https://raw.githubusercontent.com/araditc/Artalk.Xmpp/master/doap.xml",
         "name": "Artalk.Xmpp",
-        "platforms": [
-            ".NET"
-        ],
+        "platforms": [],
         "url": null
     },
     {

--- a/data/software.json
+++ b/data/software.json
@@ -77,9 +77,11 @@
         "categories": [
             "library"
         ],
-        "doap": "/hosted-doap/artalk-xmpp.doap",
-        "name": "Artalk.XMPP",
-        "platforms": [],
+        "doap": "https://raw.githubusercontent.com/araditc/Artalk.Xmpp/master/doap.xml",
+        "name": "Artalk.Xmpp",
+        "platforms": [
+            ".NET"
+        ],
         "url": null
     },
     {


### PR DESCRIPTION
## Summary

- Update the existing Artalk.Xmpp software entry with the canonical project name, .NET platform, and upstream DOAP URL.
- Add Artalk.Xmpp to the MUC and BOSH library lists in the technology overview.

## Notes

Artalk.Xmpp publishes XEP-0453-compatible DOAP metadata at:
https://raw.githubusercontent.com/araditc/Artalk.Xmpp/master/doap.xml

The project is a .NET 10 XMPP client library with basic MUC support and XMPP-over-BOSH support.