### PR TITLE
Add cr-xmpp library metadata

### DIFF
--- a/content/about/technology-overview.md
+++ b/content/about/technology-overview.md
@@ -144,6 +144,7 @@ __Libraries__
 - [libpurple](https://developer.pidgin.im/wiki/WhatIsLibpurple) (C)
 - [Smack](http://www.igniterealtime.org/projects/smack/index.jsp) (Java)
 - [XMPP4R](https://xmpp4r.github.io/) (Ruby)
+- [cr-xmpp](https://github.com/naqvis/cr-xmpp) (Crystal)
 
 ## PubSub{#pubsub}
 
@@ -244,3 +245,4 @@ The following standalone XMPP connection managers can be used with a wide variet
 - [Swiften](https://swift.im/swiften.html) (C++)
 - [XMPP4GWT](http://www.tigase.org/project/xmpp4gwt) (gwt)
 - [XMPP4R](https://xmpp4r.github.io/) (Ruby)
+- [cr-xmpp](https://github.com/naqvis/cr-xmpp) (Crystal)

--- a/content/about/technology-overview.md
+++ b/content/about/technology-overview.md
@@ -144,7 +144,6 @@ __Libraries__
 - [libpurple](https://developer.pidgin.im/wiki/WhatIsLibpurple) (C)
 - [Smack](http://www.igniterealtime.org/projects/smack/index.jsp) (Java)
 - [XMPP4R](https://xmpp4r.github.io/) (Ruby)
-- [cr-xmpp](https://github.com/naqvis/cr-xmpp) (Crystal)
 
 ## PubSub{#pubsub}
 
@@ -245,4 +244,3 @@ The following standalone XMPP connection managers can be used with a wide variet
 - [Swiften](https://swift.im/swiften.html) (C++)
 - [XMPP4GWT](http://www.tigase.org/project/xmpp4gwt) (gwt)
 - [XMPP4R](https://xmpp4r.github.io/) (Ruby)
-- [cr-xmpp](https://github.com/naqvis/cr-xmpp) (Crystal)

--- a/data/software.json
+++ b/data/software.json
@@ -2049,5 +2049,16 @@
             "JavaScript"
         ],
         "url": "https://ivan.vucica.net/zxmpp"
+    },
+    {
+        "categories": [
+            "library"
+        ],
+        "doap": "https://raw.githubusercontent.com/naqvis/cr-xmpp/refs/heads/master/doap.rdf",
+        "name": "cr-xmpp",
+        "platforms": [
+            "Crystal"
+        ],
+        "url": "https://github.com/naqvis/cr-xmpp"
     }
 ]

--- a/data/software.json
+++ b/data/software.json
@@ -390,6 +390,15 @@
     },
     {
         "categories": [
+            "library"
+        ],
+        "doap": "https://raw.githubusercontent.com/naqvis/cr-xmpp/refs/heads/master/doap.rdf",
+        "name": "cr-xmpp",
+        "platforms": [],
+        "url": null
+    },
+    {
+        "categories": [
             "client"
         ],
         "doap": "https://raw.githubusercontent.com/dino/dino/master/dino.doap",
@@ -2049,16 +2058,7 @@
             "JavaScript"
         ],
         "url": "https://ivan.vucica.net/zxmpp"
-    },
-    {
-        "categories": [
-            "library"
-        ],
-        "doap": "https://raw.githubusercontent.com/naqvis/cr-xmpp/refs/heads/master/doap.rdf",
-        "name": "cr-xmpp",
-        "platforms": [
-            "Crystal"
-        ],
-        "url": "https://github.com/naqvis/cr-xmpp"
     }
 ]
+
+


### PR DESCRIPTION
## Summary

- Add cr-xmpp software entry with the canonical project name, Crystal lang platform, and upstream DOAP URL.

## Notes

cr-xmpp publishes XEP-0453-compatible DOAP metadata at:
https://raw.githubusercontent.com/naqvis/cr-xmpp/refs/heads/master/doap.rdf

The project is a [Crystal Lang](https://crystal-lang.org/) XMPP llibrary for crystal, Its a pure Crystal event-driven toolkit for building XMPP clients, bots, automation services, connected devices, gateways, and XEP-0114 external components. 