### PR TITLE
Blogpost: OmniOpenCon stand 2026

### DIFF
--- a/content/blog/2026-omniopencon.md
+++ b/content/blog/2026-omniopencon.md
@@ -6,22 +6,14 @@ categories: ['Events', 'XMPP Community']
 summary: "The XMPP stand at OmniOpenCon has been confirmed for 16-18th October 2026"
 ---
 
-XMPP Community members will have a stand at
-[OmniOpenCon](https://omniopencon.org/) later this year.
+XMPP Community members will have a stand at [OmniOpenCon](https://omniopencon.org/) later this year.
 
-OmniOpenCon is an annual FOSS conference held at
-[Politehnica University of Bucharest](https://en.wikipedia.org/wiki/Politehnica_University_of_Bucharest)
-in Bucharest, Romania. OmniOpenCon is free to attend, and is well linked by
-public transport making it very easy to reach from anywhere in the city.
+OmniOpenCon is an annual FOSS conference held at [Politehnica University of Bucharest](https://en.wikipedia.org/wiki/Politehnica_University_of_Bucharest) in Bucharest, Romania. OmniOpenCon is free to attend, and is well linked by public transport making it very easy to reach from anywhere in the city.
 
-Currently a lot of XMPP community presence in Europe has been within Western
-Europe. Branching out to Eastern Europe will hopefully draw new members into
-the community and spread secure, open and decentralised messaging to more
-people!
+Currently a lot of XMPP community presence in Europe has been within Western Europe.
+Branching out to Eastern Europe will hopefully draw new members into the XMPP community and spread secure, open and decentralised messaging to more people!
 
-We are looking for volunteers if anyone is free to attend, please contact
-Polarian:
+We are looking for volunteers if anyone is free to attend, please contact Polarian:
 
 [XMPP: polarian@icebound.dev](xmpp:polarian@icebound.dev)  
 [Email: polarian@polarian.dev](mailto:polarian@polarian.dev)
-

--- a/content/blog/2026-omniopencon.md
+++ b/content/blog/2026-omniopencon.md
@@ -1,0 +1,27 @@
+---
+title: XMPP stand at OmniOpenCon
+date: 2026-08-04
+author: Polarian
+categories: ['Events', 'XMPP Community']
+summary: "The XMPP stand at OmniOpenCon has been confirmed for 16-18th October 2026"
+---
+
+XMPP will have a stand at [OmniOpenCon](https://omniopencon.org/) later this year.
+
+OmniOpenCon is an annual FOSS conference held at
+[Politehnica University of Bucharest](https://en.wikipedia.org/wiki/Politehnica_University_of_Bucharest)
+in Bucharest, Romania.
+
+OmniOpenCon is free to attend, and is well linked by public transport making
+it very easy to attend from anywhere in the city.
+
+Currently a lot of XMPP presence in Europe has been within Western Europe.
+Branching out to Eastern Europe will hopefully draw new members into the
+community and spread secure, open and decentralised messaging to more people!
+
+We are looking for volunteers if anyone is free to attend, please contact
+Polarian:
+
+[XMPP: polarian@icebound.dev](xmpp:polarian@icebound.dev)  
+[Email: polarian@polarian.dev](mailto:polarian@polarian.dev)
+

--- a/content/blog/2026-omniopencon.md
+++ b/content/blog/2026-omniopencon.md
@@ -6,18 +6,18 @@ categories: ['Events', 'XMPP Community']
 summary: "The XMPP stand at OmniOpenCon has been confirmed for 16-18th October 2026"
 ---
 
-XMPP will have a stand at [OmniOpenCon](https://omniopencon.org/) later this year.
+XMPP Community members will have a stand at
+[OmniOpenCon](https://omniopencon.org/) later this year.
 
 OmniOpenCon is an annual FOSS conference held at
 [Politehnica University of Bucharest](https://en.wikipedia.org/wiki/Politehnica_University_of_Bucharest)
-in Bucharest, Romania.
+in Bucharest, Romania. OmniOpenCon is free to attend, and is well linked by
+public transport making it very easy to reach from anywhere in the city.
 
-OmniOpenCon is free to attend, and is well linked by public transport making
-it very easy to attend from anywhere in the city.
-
-Currently a lot of XMPP presence in Europe has been within Western Europe.
-Branching out to Eastern Europe will hopefully draw new members into the
-community and spread secure, open and decentralised messaging to more people!
+Currently a lot of XMPP community presence in Europe has been within Western
+Europe. Branching out to Eastern Europe will hopefully draw new members into
+the community and spread secure, open and decentralised messaging to more
+people!
 
 We are looking for volunteers if anyone is free to attend, please contact
 Polarian:

--- a/data/events.json
+++ b/data/events.json
@@ -1,5 +1,14 @@
 [
     {
+        "type": "OmniOpenCon",
+        "title": "XMPP at OmniOpenCon",
+        "location": "Bucharest (RO)",
+        "date_start": "2026-10-16",
+        "date_end": "2026-10-18",
+        "url": "https://xmpp.org/2026/08/xmpp-stand-at-omniopencon/",
+        "desc": "XMPP Stand at OmniOpenCon for the first time!"
+    },
+    {
         "type": "Summit",
         "title": "XMPP Summit 29",
         "location": "online",


### PR DESCRIPTION
XMPP stand at OmniOpenCon has been confirmed for 16-18th Oct.

Their website still hasn't been updated, however the dates and stand have both been confirmed via email.