### PR TITLE
Events: Add missing 2026 events

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -18,6 +18,42 @@
         "desc": "The first online XMPP Summit"
     },
     {
+        "type": "FrOSCon",
+        "title": "XMPP at FrOSCon 2026",
+        "location": "Bonn (DE)",
+        "date_start": "2026-08-15",
+        "date_end": "2026-08-16",
+        "url": null,
+        "desc": null
+    },
+    {
+        "type": "FOSSY",
+        "title": "XMPP at FOSSY 2026",
+        "location": "Vancouver (CA)",
+        "date_start": "2026-08-06",
+        "date_end": "2026-08-08",
+        "url": "https://2026.fossy.ca/pages/tracks/",
+        "desc": null
+    },
+    {
+        "type": "Sprint",
+        "title": "XMPP Sprint in Vienna",
+        "location": "Vienna (AT)",
+        "date_start": "2026-07-18",
+        "date_end": "2026-07-19",
+        "url": "https://wiki.xmpp.org/web/Sprints/2026-07_Vienna",
+        "desc": null
+    },
+    {
+        "type": "Sprint",
+        "title": "XMPP Sprint in Berlin",
+        "location": "Berlin (DE)",
+        "date_start": "2026-06-19",
+        "date_end": "2026-06-21",
+        "url": "https://wiki.xmpp.org/web/Sprints/2026-06_Berlin",
+        "desc": null
+    },
+    {
         "type": "FOSDEM",
         "title": "XMPP at FOSDEM 2026",
         "location": "Brussels (BE)",


### PR DESCRIPTION
Numerous events, both upcoming and in the past were not added to the `events.json`, after the outcome of #1693 I thought I would at least add the missing 2026 events so they would show up as "previous events" on the website.

I have nulled the url for FrOSCon in anticipation of emus writing the blogpost for it, as discussed on XMPP.