### PR TITLE
Events: Fix FrOSCon entry

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -23,7 +23,7 @@
         "location": "Bonn (DE)",
         "date_start": "2026-08-15",
         "date_end": "2026-08-16",
-        "url": null,
+        "url": "https://xmpp.org/2026/08/xmpp-at-froscon-2026/",
         "desc": null
     },
     {


### PR DESCRIPTION
Blogpost for FrOSCon was added in e189b17725b9e275d38829c3b2345beba717ac47 however the corresponding event was not updated, this commit fixes that.