### PR TITLE
Events: Move to past events after end_date not start_date

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -148,7 +148,7 @@
         "title": null,
         "location": "Portland (US)",
         "date_start": "2023-05-30",
-        "date_end": null,
+        "date_end": "2023-05-30",
         "url": "https://2023.fossy.us/",
         "desc": "around Fossy"
     },
@@ -292,7 +292,7 @@
         "title": null,
         "location": "Brussels (BE)",
         "date_start": "2019-01-30",
-        "date_end": null,
+        "date_end": "2019-01-30",
         "url": "https://wiki.xmpp.org/web/Sprints/2019_January_Brussels",
         "desc": "around FOSDEM"
     },

--- a/themes/xmpp.org/layouts/index.html
+++ b/themes/xmpp.org/layouts/index.html
@@ -63,8 +63,10 @@
     <h3 class="text-center pb-2"><a href="/community/events/">Upcoming Events</a></h3>
     {{- $events_counter := 0 -}}
     {{- range hugo.Data.events -}}
+      {{- $current_date := (time.Format "2006-01-02" now) | time -}}
       {{- $start_date := .date_start | time -}}
-      {{- if gt $start_date now -}}
+      {{- $end_date := .date_end | time -}}
+      {{- if ge $end_date $current_date -}}
         {{- $events_counter = add $events_counter 1 -}}
         <div class="card text-bg-tertiary mb-3">
           <h5 class="card-header">
@@ -80,8 +82,9 @@
                   {{- .title -}}&nbsp;-&nbsp;
               {{- end -}}
               {{- if .date_end -}}
-                  {{- $end_date := .date_end | time -}}
-                  {{- if eq (dateFormat "January" $start_date) (dateFormat "January" $end_date) -}}
+                  {{- if eq (dateFormat "January 2" $start_date) (dateFormat "January 2" $end_date) -}}
+                      {{- dateFormat "January 2" $start_date -}}
+                  {{- else if eq (dateFormat "January" $start_date) (dateFormat "January" $end_date) -}}
                       {{- dateFormat "January 2" $start_date -}}-{{- dateFormat "2, 2006" $end_date -}}
                   {{- else -}}
                       {{- dateFormat "January 2" $start_date -}}-{{- dateFormat "January 2, 2006" $end_date -}}

--- a/themes/xmpp.org/layouts/shortcodes/events.html
+++ b/themes/xmpp.org/layouts/shortcodes/events.html
@@ -5,10 +5,11 @@
 {{- end -}}
 {{- $events_counter := 0 -}}
 {{- range hugo.Data.events -}}
+    {{- $current_date := (time.Format "2006-01-02" now) | time -}}
     {{- $start_date := .date_start | time -}}
     {{- $end_date := .date_end | time -}}
     {{- if eq $type "upcoming" -}}
-        {{- if gt $end_date now -}}
+        {{- if ge $end_date $current_date -}}
             {{- $events_counter = add $events_counter 1 -}}
             <div class="row">
                 <div class="col-12 col-md-10 col-lg-8">
@@ -26,7 +27,9 @@
                                     {{- .title -}}&nbsp;-&nbsp;
                                 {{- end -}}
                                 {{- if .date_end -}}
-                                    {{- if eq (dateFormat "January" $start_date) (dateFormat "January" $end_date) -}}
+                                    {{- if eq (dateFormat "January 2" $start_date) (dateFormat "January 2" $end_date) -}}
+                                        {{- dateFormat "January 2" $start_date -}}
+                                    {{- else if eq (dateFormat "January" $start_date) (dateFormat "January" $end_date) -}}
                                         {{- dateFormat "January 2" $start_date -}}-{{- dateFormat "2, 2006" $end_date -}}
                                     {{- else -}}
                                         {{- dateFormat "January 2" $start_date -}}-{{- dateFormat "January 2, 2006" $end_date -}}
@@ -49,7 +52,7 @@
     {{- end -}}
 
     {{- if eq $type "past" -}}
-        {{- if lt $end_date now -}}
+        {{- if lt $end_date $current_date -}}
         <li>
             {{- .type -}}: <a href="{{- .url -}}">
             {{- .location -}}&nbsp;-&nbsp;

--- a/themes/xmpp.org/layouts/shortcodes/events.html
+++ b/themes/xmpp.org/layouts/shortcodes/events.html
@@ -6,8 +6,9 @@
 {{- $events_counter := 0 -}}
 {{- range hugo.Data.events -}}
     {{- $start_date := .date_start | time -}}
+    {{- $end_date := .date_end | time -}}
     {{- if eq $type "upcoming" -}}
-        {{- if gt $start_date now -}}
+        {{- if gt $end_date now -}}
             {{- $events_counter = add $events_counter 1 -}}
             <div class="row">
                 <div class="col-12 col-md-10 col-lg-8">
@@ -25,7 +26,6 @@
                                     {{- .title -}}&nbsp;-&nbsp;
                                 {{- end -}}
                                 {{- if .date_end -}}
-                                    {{- $end_date := .date_end | time -}}
                                     {{- if eq (dateFormat "January" $start_date) (dateFormat "January" $end_date) -}}
                                         {{- dateFormat "January 2" $start_date -}}-{{- dateFormat "2, 2006" $end_date -}}
                                     {{- else -}}
@@ -49,7 +49,7 @@
     {{- end -}}
 
     {{- if eq $type "past" -}}
-        {{- if lt $start_date now -}}
+        {{- if lt $end_date now -}}
         <li>
             {{- .type -}}: <a href="{{- .url -}}">
             {{- .location -}}&nbsp;-&nbsp;


### PR DESCRIPTION
Currently events are moved to `past_events` during the conference as the past events are checked against the `start_date` not `end_date`.

This patch fixes this by checking against the `end_date` instead