### PR TITLE
Disable announcement for Summit 29

### DIFF
--- a/data/announcement.json
+++ b/data/announcement.json
@@ -1,5 +1,5 @@
 {
-    "enabled": true,
-    "text": "XMPP Summit 29 - Join us online on 4th - 5th Sep 2026",
+    "enabled": false,
+    "text": "XMPP Summit 30 - Join us in Brussels on 28 & 29 January 2027",
     "url": "https://xmpp.org/2026/05/xmpp-summit-29/"
 }


### PR DESCRIPTION
Summit 29 has happened, let's no longer announce it.

I've updated the announcement text to reference the future Summit 30, but have not enabled that announcement yet. We should wait until we have a corresponding blog post for that.

This PR can/should be merged, as the net effect is that the existing announcement for Summit 29 will be removed (while no other announcement is put back in place).