### PR TITLE
Members: Add all polarian's JIDs

### DIFF
--- a/data/members.json
+++ b/data/members.json
@@ -394,7 +394,9 @@
         {
             "name": "George Timms",
             "jids": [
-                "polarian@icebound.dev"
+                "polarian@icebound.dev",
+                "polarian+muc@icebound.dev",
+                "admin@icebound.dev"
             ]
         },
         {


### PR DESCRIPTION
I have multiple JIDs for different things, my personal JID is only used for discussion in PMs (like for voting) however I am not voiced within XSF channels due to my muc JID missing.

I have also added the admin JID I use within the XSF operators MUC. This should solve any potential problems in the future. 